### PR TITLE
Fix shortcuts attributes parsing

### DIFF
--- a/lib/slim_fast/parser.ex
+++ b/lib/slim_fast/parser.ex
@@ -66,7 +66,7 @@ defmodule SlimFast.Parser do
   end
 
   defp html_id(input) do
-    case Regex.run(~r/^#([\w-]{1,})/, input) do
+    case Regex.run(~r/#([\w-]{1,})/, input) do
       [_, id] -> [id: id]
       _ -> []
     end

--- a/lib/slim_fast/parser.ex
+++ b/lib/slim_fast/parser.ex
@@ -120,10 +120,11 @@ defmodule SlimFast.Parser do
   end
 
   defp parse_tag(input) do
-      tag = case Regex.run(~r/^([\w]*)[:#.]?/, input) do
-              [_, ""] -> :div
-              [_, tag] -> String.to_atom(tag)
-            end
+    [input | _] = String.split(input, " ", parts: 2)
+    tag = case Regex.run(~r/^(\w*)[:#\.]?/, input) do
+            [_, ""] -> :div
+            [_, tag] -> String.to_atom(tag)
+          end
 
     {tag, css_classes(input) ++ html_id(input)}
   end

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -57,4 +57,8 @@ defmodule RendererTest do
       ~s(meta content="width=device-width, initial-scale=1" name="viewport")
     ) == ~s(<meta name="viewport" content="width=device-width, initial-scale=1">)
   end
+
+  test "render tag with inline child containing dot should not produce class attribute" do
+    assert render(~s(div test.class)) == ~s(<div>test.class</div>)
+  end
 end

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -61,4 +61,8 @@ defmodule RendererTest do
   test "render tag with inline child containing dot should not produce class attribute" do
     assert render(~s(div test.class)) == ~s(<div>test.class</div>)
   end
+
+  test "render tag with id after tag name should produce id attribute" do
+    assert render(~s(span#id)) == ~s(<span id="id"></span>)
+  end
 end


### PR DESCRIPTION
With this fix `div example.com` produces `<div>example.com</div>` instead of `<div class="com">example.com</div>`

Also `#id` shortcut now works after tag name: `span#id` produces `<span id="id"></span>`
