### PR TITLE
Add comment support

### DIFF
--- a/lib/slim_fast/compiler.ex
+++ b/lib/slim_fast/compiler.ex
@@ -41,12 +41,16 @@ defmodule SlimFast.Compiler do
     "<%#{inline} #{code} %>"
   end
 
+  defp open(_, %{type: :html_comment}), do: "<!--"
+  defp open(_, %{type: :ie_comment, content: conditions}), do: "<!--[#{conditions}]>"
   defp open(attrs, %{type: type}) do
     type = String.rstrip("#{type} #{attrs}")
     "<#{type}>"
   end
 
   defp close(%{type: type}) when type in @self_closing, do: ""
+  defp close(%{type: :html_comment}), do: "-->"
+  defp close(%{type: :ie_comment}), do: "<![endif]-->"
   defp close(%{type: :eex, content: code}) do
     cond do
       Regex.match? ~r/(fn.*->|do:?)/, code -> "<% end %>"

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -84,4 +84,18 @@ defmodule ParserTest do
     parsed = ["#id.class", "\tp", "\t| Hello World", ""] |> Parser.parse_lines
     assert parsed == [{0, {:div, attributes: [class: ["class"], id: "id"], children: []}}, {2, {:p, attributes: [], children: []}}, {2, "Hello World"}]
   end
+
+  test "parses html comments" do
+    {_, {:html_comment, opts}} = Parser.parse_line("/! html comment")
+    assert opts[:children] == ["html comment"]
+  end
+
+  test "parses IE comments" do
+    {_, {:ie_comment, opts}} = Parser.parse_line("/[if IE]")
+    assert opts[:content] == "if IE"
+  end
+
+  test "parses code comments" do
+    {_, ""} = Parser.parse_line("/ code comment")
+  end
 end

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -65,4 +65,21 @@ defmodule RendererTest do
   test "render tag with id after tag name should produce id attribute" do
     assert render(~s(span#id)) == ~s(<span id="id"></span>)
   end
+
+  test "render html comments" do
+    assert render(~s(/! html comment)) == ~s(<!--html comment-->)
+  end
+
+  test "render IE comments" do
+    assert render(~s(/[if IE] html comment)) == ~s(<!--[if IE]>html comment<![endif]-->)
+  end
+
+  test "does not render code comments" do
+    slim = """
+    / code comment
+      p.test
+    """
+
+    assert render(slim) == ~s(<p class="test"></p>)
+  end
 end


### PR DESCRIPTION
This PR adds support for three types of comments per slim's docs:
- [Code comments](https://github.com/slim-template/slim#code-comment-t-) - `/! comment`
- [HTML comments](https://github.com/slim-template/slim#html-comment-) - `/ comment`
- [IE conditional comments](https://github.com/slim-template/slim#ie-conditional-comment-) - `/[if IE] comment`

Closes #8 
