### PR TITLE
EEx-like templates precompilation macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ With this:
 SlimFast.render(slim, site_title: "Website Title")
 ```
 
+## Precompilation
+
+Templates can be compiled into module functions like EEx templates, using functions
+`SlimFast.function_from_file/5` and `SlimFast.function_from_string/5`.
+
 ## Contributing
 
 Please do.  New code should have accompanying tests.

--- a/lib/slim_fast.ex
+++ b/lib/slim_fast.ex
@@ -8,4 +8,49 @@ defmodule SlimFast do
       use SlimFast.Renderer
     end
   end
+
+  @doc """
+  Generates a function definition from the file contents.
+  The kind (`:def` or `:defp`) must be given, the
+  function name, its arguments and the compilation options.
+  This function is useful in case you have templates but
+  you want to precompile inside a module for speed.
+  ## Examples
+      # sample.slim
+      = a + b
+      # sample.ex
+      defmodule Sample do
+        require SlimFast
+        SlimFast.function_from_file :def, :sample, "sample.slim", [:a, :b]
+      end
+      # iex
+      Sample.sample(1, 2) #=> "3"
+  """
+  defmacro function_from_file(kind, name, file, args \\ [], options \\ []) do
+    quote bind_quoted: binding do
+      require EEx
+      eex = file |> File.read! |> SlimFast.Renderer.precompile
+      EEx.function_from_string(kind, name, eex, args, options)
+    end
+  end
+
+  @doc """
+  Generates a function definition from the string.
+  The kind (`:def` or `:defp`) must be given, the
+  function name, its arguments and the compilation options.
+  ## Examples
+      iex> defmodule Sample do
+      ...>   require SlimFast
+      ...>   SlimFast.function_from_string :def, :sample, "= a + b", [:a, :b]
+      ...> end
+      iex> Sample.sample(1, 2)
+      "3"
+  """
+  defmacro function_from_string(kind, name, source, args \\ [], options \\ []) do
+    quote bind_quoted: binding do
+      require EEx
+      eex = source |> SlimFast.Renderer.precompile
+      EEx.function_from_string(kind, name, eex, args, options)
+    end
+  end
 end

--- a/test/slim_fast_test.exs
+++ b/test/slim_fast_test.exs
@@ -1,4 +1,4 @@
 defmodule SlimFastTest do
   use ExUnit.Case
-
+  doctest SlimFast
 end


### PR DESCRIPTION
`SlimFast.function_from_file/5` and `SlimFast.function_from_string/5` macros, compiles slim into module function for speed.
