### PR TITLE
Fix regex in Parser.parse_eex/2

### DIFF
--- a/lib/slim_fast/parser.ex
+++ b/lib/slim_fast/parser.ex
@@ -95,7 +95,7 @@ defmodule SlimFast.Parser do
   defp parse_eex(input, inline \\ false) do
     input = String.lstrip(input)
     script = input
-             |> String.split(~r/^[-|=|==]/)
+             |> String.split(~r/^(-|==|=)/)
              |> List.last
              |> String.lstrip
     inline = inline or String.starts_with?(input, "=")

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -133,4 +133,14 @@ defmodule ParserTest do
   test "parses code comments" do
     {_, ""} = Parser.parse_line("/ code comment")
   end
+
+  test "parses outputs" do
+    {_, {:eex, opts}} = Parser.parse_line("= elixir_func")
+    assert opts[:inline] == true
+    assert opts[:content] == "elixir_func"
+
+    {_, {:eex, opts}} = Parser.parse_line("== elixir_func")
+    assert opts[:inline] == true
+    assert opts[:content] == "elixir_func"
+  end
 end


### PR DESCRIPTION
`Paser.parse_line/1` used to fail to parse `==` line:

``` ex
iex> SlimFast.Parser.parse_line("== foo")
{0, {:eex, [content: "= foo", inline: true]}}
# content should be "foo"
```

This PR fixes it:

``` ex
iex> SlimFast.Parser.parse_line("== foo")
{0, {:eex, [content: "foo", inline: true]}}
```
