### PR TITLE
Add support for quotation inside interpolation in attributes

### DIFF
--- a/lib/slim_fast/parser.ex
+++ b/lib/slim_fast/parser.ex
@@ -22,7 +22,7 @@ defmodule SlimFast.Parser do
     "xml":            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"]
 
   @attr_delim_regex ~r/[ ]+(?=([^"]*"[^"]*")*[^"]*$)/
-  @attr_group_regex ~r/(?:\s*[\w-]+\s*=\s*(?:[^\s"'][^\s]+[^\s"']|"[^"]*"|'[^']*'))*/
+  @attr_group_regex ~r/(?:\s*[\w-]+\s*=\s*(?:[^\s"'][^\s]+[^\s"']|"(?:(?<z>\{(?:[^{}]|\g<z>)*\})|[^"])*"|'[^']*'))*/
   @tag_regex ~r/\A(?<tag>\w*)(?:#(?<id>[\w-]*))?(?<css>(?:\.[\w-]*)*)?/
   @verbatim_text_regex ~r/^(\s*)([#{@content}#{@preserved}])\s?/
 
@@ -104,7 +104,7 @@ defmodule SlimFast.Parser do
 
   defp parse_eex_string(input) do
     if String.contains?(input, "\#{") do
-      script = "\"#{String.replace(input, "\"", "\\\"")}\""
+      script = "\"#{String.replace(input, ~r/^(?<z>[^{}]*|\#\{\g<z>*\})*\K"/, "\\\\\"")}\""
       {:eex, content: script, inline: true}
     else
       input

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -55,6 +55,18 @@ defmodule ParserTest do
     assert opts[:attributes] == [content: {:eex, content: ~S("one#{two}"), inline: true}]
   end
 
+  test "parses attributes with qutation inside interoplation correctly" do
+    {_, {:meta, opts}} = ~S[meta content="one#{two("three")}"] |> Parser.parse_line
+
+    assert opts[:attributes] == [content: {:eex, content: ~S["one#{two("three")}"], inline: true}]
+  end
+
+  test "parses attributes with tuples inside interoplation correctly" do
+    {_, {:meta, opts}} = ~S[meta content="one#{two({"three" "four"})}"] |> Parser.parse_line
+
+    assert opts[:attributes] == [content: {:eex, content: ~S["one#{two({"three" "four"})}"], inline: true}]
+  end
+
   test "parses attributes with elixir code" do
     {_, {:meta, opts}} = ~S(meta content=@user.name) |> Parser.parse_line
     assert opts[:attributes] == [content: {:eex, content: ~S(@user.name), inline: true}]
@@ -113,6 +125,12 @@ defmodule ParserTest do
     {_, {:eex, opts}} = Parser.parse_line(~S(<h3>Text" #{elixir_func}</h3>))
     assert opts[:inline] == true
     assert opts[:content] == "\"<h3>Text\\\" \#{elixir_func}</h3>\""
+  end
+
+  test "quote inline html with interpolation" do
+    {_, {:eex, opts}} = Parser.parse_line(~S(<h3>Text" #{"elixir_string"}</h3>))
+    assert opts[:inline] == true
+    assert opts[:content] == "\"<h3>Text\\\" \#{\"elixir_string\"}</h3>\""
   end
 
   test "parses final newline properly" do

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -213,6 +213,8 @@ defmodule RendererTest do
     assert render(~s(div [a b="b"] c)) == ~s(<div a b="b">c</div>)
     assert render(~S(div ab="#{b} a" a), b: "b") == ~s(<div ab="b a">a</div>)
     assert render(~S(div[ab="a #{b}" a] a), b: "b") == ~s(<div ab="a b" a>a</div>)
+    assert render(~S<div[ab="a #{b.("c")}" a] a>, b: &(&1)) == ~s(<div ab="a c" a>a</div>)
+    assert render(~S<div[ab="a #{b.({"c", "d"})}" a] a>, b: fn {_, r} -> r end) == ~s(<div ab="a d" a>a</div>)
     assert render(~s(script[defer async src="..."])) == ~s(<script defer async src="..."></script>)
   end
 end


### PR DESCRIPTION
Original (ruby) implementation counts curly braces occurrences with ruby code and ignores quotes occurrences unless they are balanced. I implemented the same approach only with recursive regular expressions.
