### PR TITLE
Fix over-escaping in attributes quotes when using Phoenix.HTML.Engine

### DIFF
--- a/lib/slim_fast/compiler.ex
+++ b/lib/slim_fast/compiler.ex
@@ -15,7 +15,7 @@ defmodule SlimFast.Compiler do
       "true" -> " #{to_string(name)}"
       "false" -> ""
       "nil" -> ""
-      _ ->  ~s[<%= __k = "#{to_string(name)}"; __v = #{value}; if __v == true, do: " " <> __k, else: (if __v, do: ~s( \#{__k}="\#{__v}")) %>]
+      _ ->  ~s[<% __k = "#{to_string(name)}"; __v = #{value} %><%= if __v do %> <%= __k %><%= unless __v == true do %>="<%= __v %>"<% end %><% end %>]
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule SlimFast.Mixfile do
   def project do
     [app: :slim_fast,
      build_embedded: Mix.env == :prod,
-     deps: [],
+     deps: deps,
      description: """
      An Elixir library for rendering slim templates.
      """,
@@ -22,5 +22,11 @@ defmodule SlimFast.Mixfile do
      files: ["lib", "mix.exs", "README*", "LICENSE*"],
      licenses: ["MIT"],
      links: %{github: "https://github.com/doomspork/slim_fast"}]
+  end
+
+  def deps do
+    [
+      {:phoenix_html, "~> 2.2", only: :test}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"phoenix_html": {:hex, :phoenix_html, "2.2.0"},
+  "plug": {:hex, :plug, "1.0.2"}}

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -12,7 +12,7 @@ defmodule CompilerTest do
                                               children: [],
                                                content: "Hello World"}]}]}]
 
-    expected = ~S[<div<%= __k = "id"; __v = variable; if __v == true, do: " " <> __k, else: (if __v, do: ~s( #{__k}="#{__v}")) %> class="class"><p>Hello World</p></div>]
+    expected = ~S[<div<% __k = "id"; __v = variable %><%= if __v do %> <%= __k %><%= unless __v == true do %>="<%= __v %>"<% end %><% end %> class="class"><p>Hello World</p></div>]
     assert Compiler.compile(tree) == expected
   end
 

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -237,4 +237,24 @@ defmodule RendererTest do
     assert render("div a=meta", meta: nil) == ~s(<div></div>)
     assert render("div a=meta", meta: false) == ~s(<div></div>)
   end
+
+  test "do not overescape quotes in attributes" do
+    defmodule RenderHelperMethodWithQuotesArguments do
+      require SlimFast
+
+      def static_path(path) do
+        path
+      end
+
+      @slim ~s[link rel="stylesheet" href=static_path("/css/app.css")]
+      SlimFast.function_from_string(:def, :pre_render, @slim, [], engine: Phoenix.HTML.Engine)
+
+      def render do
+        pre_render |> Phoenix.HTML.Safe.to_iodata |> IO.iodata_to_binary
+      end
+    end
+
+    assert RenderHelperMethodWithQuotesArguments.render ==
+      ~s(<link rel="stylesheet" href="/css/app.css">)
+  end
 end


### PR DESCRIPTION
Fixes #37 
