### PR TITLE
Fix __variable warnings

### DIFF
--- a/lib/slim_fast/compiler.ex
+++ b/lib/slim_fast/compiler.ex
@@ -15,7 +15,7 @@ defmodule SlimFast.Compiler do
       "true" -> " #{to_string(name)}"
       "false" -> ""
       "nil" -> ""
-      _ ->  ~s[<% __k = "#{to_string(name)}"; __v = #{value} %><%= if __v do %> <%= __k %><%= unless __v == true do %>="<%= __v %>"<% end %><% end %>]
+      _ ->  ~s[<% slim__k = "#{to_string(name)}"; slim__v = #{value} %><%= if slim__v do %> <%= slim__k %><%= unless slim__v == true do %>="<%= slim__v %>"<% end %><% end %>]
     end
   end
 

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -12,7 +12,7 @@ defmodule CompilerTest do
                                               children: [],
                                                content: "Hello World"}]}]}]
 
-    expected = ~S[<div<% __k = "id"; __v = variable %><%= if __v do %> <%= __k %><%= unless __v == true do %>="<%= __v %>"<% end %><% end %> class="class"><p>Hello World</p></div>]
+    expected = ~S[<div<% slim__k = "id"; slim__v = variable %><%= if slim__v do %> <%= slim__k %><%= unless slim__v == true do %>="<%= slim__v %>"<% end %><% end %> class="class"><p>Hello World</p></div>]
     assert Compiler.compile(tree) == expected
   end
 


### PR DESCRIPTION
Like

```
warning: the underscored variable "__v" is used after being set. A
leading underscore indicates that the value of the variable should be
ignored. If this is intended please rename the variable to remove the
underscore
```

Keeping the double underscores to make variable collisions extra unlikely.
