### PR TITLE
Add language reference section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ p My cat's name is #{name}
 ```
 
 
+### Comments
+
+Lines can be commented out using the `/` character.
+
+```slim
+/ p This line is commented out
+p This line is not
+```
+```html
+<p>This line is not</p>
+```
+
+HTML `<!-- -->` comments can be inserted using `/!`
+```slim
+/! Hello, world!
+```
+```html
+<!-- Hello, world! -->
+```
+
+
 ## Phoenix
 
 To use slim templates (and SlimFast) with [Phoenix][phoenix], please see

--- a/README.md
+++ b/README.md
@@ -194,6 +194,35 @@ doctype mobile
 ```
 
 
+### Iteration
+
+Elixir's collection manipulation expressions can be used to iterate over
+collections in your templates.
+
+```slim
+- names = ["Sarah", "Mia", "Harry"]
+
+/! Enum.map
+= Enum.map names, fn name ->
+  p = name
+
+/! for comprehension
+= for name <- names do
+  h1 = name
+```
+```html
+<!-- Enum.map -->
+<p>Sarah</p>
+<p>Mia</p>
+<p>Harry</p>
+
+<!-- for comprehension -->
+<h1>Sarah</h1>
+<h1>Mia</h1>
+<h1>Harry</h1>
+```
+
+
 ## Phoenix
 
 To use slim templates (and SlimFast) with [Phoenix][phoenix], please see

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-# SlimFast [![Build Status](https://travis-ci.org/doomspork/slim_fast.png?branch=master)](https://travis-ci.org/doomspork/slim_fast) [![Hex Version](https://img.shields.io/hexpm/v/slim_fast.svg)](https://hex.pm/packages/slim_fast) [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+# SlimFast [![Build Status][travis-img]][travis] [![Hex Version][hex-img]][hex] [![License][license-img]][license]
+
+[travis-img]: https://travis-ci.org/doomspork/slim_fast.png?branch=master
+[travis]: https://travis-ci.org/doomspork/slim_fast
+[hex-img]: https://img.shields.io/hexpm/v/slim_fast.svg
+[hex]: https://hex.pm/packages/slim_fast
+[license-img]: http://img.shields.io/badge/license-MIT-brightgreen.svg
+[license]: http://opensource.org/licenses/MIT
 
 > A refreshing way to slim down your markup in Elixir.
 
-SlimFast is an [Elixir](http://elixir-lang.com) library for rendering [Slim](http://slim-lang.com) templates as HTML.
+SlimFast is an [Elixir](http://elixir-lang.com) library for rendering
+[Slim](http://slim-lang.com)-like templates as HTML.
 
 Easily turn this:
 
@@ -21,7 +29,7 @@ html
 
 Into this:
 
-```erb
+```html
 <!DOCTYPE html>
 <html>
 <head>
@@ -46,22 +54,33 @@ With this:
 SlimFast.render(slim, site_title: "Website Title")
 ```
 
+
 ## Phoenix
 
-To use slim templates (and SlimFast) with [Phoenix](http://www.phoenixframework.org/), please see [PhoenixSlim](https://github.com/doomspork/phoenix_slim).
+To use slim templates (and SlimFast) with [Phoenix][phoenix], please see
+[PhoenixSlim][phoenix-slim].
+
+[phoenix]: http://www.phoenixframework.org/
+[phoenix-slim]: https://github.com/doomspork/phoenix_slim
+
 
 ## Precompilation
 
-Templates can be compiled into module functions like EEx templates, using functions
-`SlimFast.function_from_file/5` and `SlimFast.function_from_string/5`.
+Templates can be compiled into module functions like EEx templates, using
+functions `SlimFast.function_from_file/5` and
+`SlimFast.function_from_string/5`.
+
 
 ## Differences to Ruby Slim
 
-We aim for feature parity with the original [Slim](http://slim-lang.com) implementation, but we deviate in some respects. We do this to be true to Elixir – just like the original Slim implementation is true to its Ruby foundations.
+We aim for feature parity with the original [Slim](http://slim-lang.com)
+implementation, but we deviate in some respects. We do this to be true to
+Elixir – just like the original Slim implementation is true to its Ruby
+foundations.
 
 For example, in SlimFast you do
 
-```
+```slim
 = if condition do
   p It was true.
 - else
@@ -70,19 +89,29 @@ For example, in SlimFast you do
 
 where Ruby Slim would do
 
-```
+```slim
 - if condition
   p It was true.
 - else
   p It was false.
 ```
 
-Note the `do` and the initial `=`, because we render the return value of the conditional as a whole.
+Note the `do` and the initial `=`, because we render the return value of the
+conditional as a whole.
+
 
 ## Contributing
 
-Feedback, feature requests, and fixes are welcomed and encouraged.  Please make appropriate use of [Issues](https://github.com/doomspork/slim_fast/issues) and [Pull Requests](https://github.com/doomspork/slim_fast/pulls).  All code should have accompanying tests.
+Feedback, feature requests, and fixes are welcomed and encouraged.  Please
+make appropriate use of [Issues][issues] and [Pull Requests][pulls].  All code
+should have accompanying tests.
+
+[issues]: https://github.com/doomspork/slim_fast/issues
+[pulls]: https://github.com/doomspork/slim_fast/pulls
+
 
 ## License
 
-Please see [LICENSE](https://github.com/doomspork/slim_fast/blob/master/LICENSE) for licensing details.
+MIT license. Please see [LICENSE][license] for details.
+
+[LICENSE]: https://github.com/doomspork/slim_fast/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -168,6 +168,32 @@ p It was true.
 ```
 
 
+### Doctype
+
+There are shortcuts for common doctypes.
+
+```slim
+doctype html
+doctype xml
+doctype transitional
+doctype strict
+doctype frameset
+doctype 1.1
+doctype basic
+doctype mobile
+```
+```html
+<!DOCTYPE html>
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">
+<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
+```
+
+
 ## Phoenix
 
 To use slim templates (and SlimFast) with [Phoenix][phoenix], please see

--- a/README.md
+++ b/README.md
@@ -9,8 +9,17 @@
 
 > A refreshing way to slim down your markup in Elixir.
 
-SlimFast is an [Elixir](http://elixir-lang.com) library for rendering
-[Slim](http://slim-lang.com)-like templates as HTML.
+SlimFast is an [Elixir][elixir] library for rendering [Slim][slim]-like
+templates as HTML.
+
+For use with [Phoenix][phoenix], please see [PhoenixSlim][phoenix-slim].
+
+[slim]: http://slim-lang.com
+[elixir]: http://elixir-lang.com
+[phoenix]: http://www.phoenixframework.org/
+[phoenix-slim]: https://github.com/doomspork/phoenix_slim
+
+
 
 Easily turn this:
 
@@ -221,15 +230,6 @@ collections in your templates.
 <h1>Mia</h1>
 <h1>Harry</h1>
 ```
-
-
-## Phoenix
-
-To use slim templates (and SlimFast) with [Phoenix][phoenix], please see
-[PhoenixSlim][phoenix-slim].
-
-[phoenix]: http://www.phoenixframework.org/
-[phoenix-slim]: https://github.com/doomspork/phoenix_slim
 
 
 ## Precompilation

--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ HTML `<!-- -->` comments can be inserted using `/!`
 ```
 
 
+### Conditionals
+
+We can use the regular Elixir flow control such as the `if` expression.
+
+```slim
+- condition = true
+= if condition do
+  p It was true.
+- else
+  p It was false.
+```
+```html
+p It was true.
+```
+
+
 ## Phoenix
 
 To use slim templates (and SlimFast) with [Phoenix][phoenix], please see

--- a/README.md
+++ b/README.md
@@ -55,6 +55,56 @@ SlimFast.render(slim, site_title: "Website Title")
 ```
 
 
+## Reference
+
+### Attributes
+
+Attributes can be assigned in a similar fashion to regular HTML.
+
+```slim
+a href="elixir-lang.org" target="_blank" Elixir
+```
+```html
+<a href="elixir-lang.org" target="_blank">Elixir</a>
+```
+
+Elixir expressions can be used as attribute values using the interpolation
+syntax.
+
+```slim
+a href="#{my_variable}" Elixir
+```
+```html
+<a href="elixir-lang.org">Elixir</a>
+```
+
+Boolean attributes can be set using boolean values
+
+```slim
+input type="checkbox" checked=true
+input type="checkbox" checked=false
+```
+```html
+<input type="checkbox" checked>
+<input type="checkbox">
+```
+
+There is a literal syntax for class and id attributes
+
+```slim
+.foo.bar
+select.bar
+#foo
+body#bar
+```
+```html
+<div class="foo bar"></div>
+<select class="bar"></select>
+<div id"foo"></div>
+<body id="bar"></body>
+```
+
+
 ## Phoenix
 
 To use slim templates (and SlimFast) with [Phoenix][phoenix], please see

--- a/README.md
+++ b/README.md
@@ -105,6 +105,32 @@ body#bar
 ```
 
 
+### Code
+
+Elixir can be written inline using `-` and `=`.
+
+`-` evalutes the expression.
+`=` evalutes the expression, and then inserts the value into template.
+
+```slim
+- number = 40
+p = number + 2
+```
+```html
+<p>42</p>
+```
+
+The interpolation syntax can be used to insert expressions into text.
+
+```slim
+- name = "Felix"
+p My cat's name is #{name}
+```
+```html
+<p>My cat's name is Felix</p>
+```
+
+
 ## Phoenix
 
 To use slim templates (and SlimFast) with [Phoenix][phoenix], please see

--- a/lib/slim_fast.ex
+++ b/lib/slim_fast.ex
@@ -15,14 +15,18 @@ defmodule SlimFast do
   function name, its arguments and the compilation options.
   This function is useful in case you have templates but
   you want to precompile inside a module for speed.
+
   ## Examples
+
       # sample.slim
       = a + b
+
       # sample.ex
       defmodule Sample do
         require SlimFast
         SlimFast.function_from_file :def, :sample, "sample.slim", [:a, :b]
       end
+
       # iex
       Sample.sample(1, 2) #=> "3"
   """
@@ -38,7 +42,9 @@ defmodule SlimFast do
   Generates a function definition from the string.
   The kind (`:def` or `:defp`) must be given, the
   function name, its arguments and the compilation options.
+
   ## Examples
+
       iex> defmodule Sample do
       ...>   require SlimFast
       ...>   SlimFast.function_from_string :def, :sample, "= a + b", [:a, :b]


### PR DESCRIPTION
#56

I think it might be nice to later extract this into a little website like Jade does http://jade-lang.com/reference/

Perhaps we could make a github organisation for this project and host it with github pages.
i.e. github.com/slim**e**-template
