### PR TITLE
Refactoring: Establish clear boundaries between modules

### DIFF
--- a/lib/slime.ex
+++ b/lib/slime.ex
@@ -27,7 +27,7 @@ defmodule Slime do
       # sample.ex
       defmodule Sample do
         require Slime
-        Slime.function_from_file :def, :sample, "sample.slim", [:a, :b]
+        Slime.function_from_file :def, :sample, "sample.slime", [:a, :b]
       end
 
       # iex

--- a/lib/slime.ex
+++ b/lib/slime.ex
@@ -2,15 +2,9 @@ defmodule Slime do
   @moduledoc """
   Slim-like HTML templates.
   """
+
+  defdelegate render(slime),           to: Slime.Renderer
   defdelegate render(slime, bindings), to: Slime.Renderer
-
-  defmacro __using__([]) do
-    quote do
-      import unquote __MODULE__
-
-      use Slime.Renderer
-    end
-  end
 
   @doc """
   Generates a function definition from the file contents.

--- a/lib/slime.ex
+++ b/lib/slime.ex
@@ -2,7 +2,7 @@ defmodule Slime do
   @moduledoc """
   Slim-like HTML templates.
   """
-  use Slime.Renderer
+  defdelegate render(slime, bindings), to: Slime.Renderer
 
   defmacro __using__([]) do
     quote do

--- a/lib/slime/parser.ex
+++ b/lib/slime/parser.ex
@@ -5,7 +5,6 @@ defmodule Slime.Parser do
 
   alias Slime.Parser.AttributesKeyword
 
-  @blank    ""
   @content  "|"
   @comment  "/"
   @html     "<"
@@ -80,7 +79,7 @@ defmodule Slime.Parser do
     end
   end
 
-  def parse_line(@blank), do: nil
+  def parse_line(""), do: nil
   def parse_line(line) do
     {indentation, line} = strip_line(line)
 
@@ -113,7 +112,7 @@ defmodule Slime.Parser do
     [{key, value}]
   end
 
-  defp html_id(@blank), do: []
+  defp html_id(""), do: []
   defp html_id(id), do: [id: id]
 
   defp parse_comment("!" <> comment), do: {:html_comment, children: [String.strip(comment)]}
@@ -178,7 +177,7 @@ defmodule Slime.Parser do
     parse_attributes(tail, attr ++ acc)
   end
 
-  defp parse_inline(@blank), do: []
+  defp parse_inline(""), do: []
   defp parse_inline(@smart <> content) do
     content
     |> parse_eex(true)
@@ -191,7 +190,7 @@ defmodule Slime.Parser do
     |> List.wrap
   end
 
-  defp parse_line(@blank, _line),    do: @blank
+  defp parse_line("", _line),        do: ""
   defp parse_line(@content, line),   do: line |> String.slice(1..-1) |> String.strip |> parse_eex_string
   defp parse_line(@comment, line),   do: line |> String.slice(1..-1) |> parse_comment
   defp parse_line(@html, line),      do: line |> String.strip |> parse_eex_string

--- a/lib/slime/renderer.ex
+++ b/lib/slime/renderer.ex
@@ -32,7 +32,7 @@ defmodule Slime.Renderer do
   """
   def render(slime, bindings \\ []) do
     slime
-    |> unquote(__MODULE__).precompile
+    |> precompile
     |> EEx.eval_string(bindings)
   end
 end

--- a/lib/slime/renderer.ex
+++ b/lib/slime/renderer.ex
@@ -2,9 +2,9 @@ defmodule Slime.Renderer do
   @moduledoc """
   Transform Slime templates into HTML.
   """
-  import Slime.Parser
-  import Slime.Compiler
-  import Slime.Tree
+  alias Slime.Parser
+  alias Slime.Compiler
+  alias Slime.Tree
 
   @doc """
   Compile Slime template to valid EEx HTML.
@@ -15,58 +15,31 @@ defmodule Slime.Renderer do
   """
   def precompile(input) do
     input
-    |> tokenize
-    |> parse_lines
-    |> build_tree
-    |> compile
+    |> String.split("\n")
+    |> Parser.parse_lines
+    |> Tree.build_tree
+    |> Compiler.compile
   end
 
-  @doc """
-  Evaluate HTML with EEx using the provided bindings.
-
-  ## Examples
-      iex> Slime.Renderer.eval("<span><%= val %></span>", val: 4)
-      "<span>4</span>"
-  """
-  def eval(html, binding) do
-    html |> EEx.eval_string(binding)
-  end
 
   @doc """
-  Split the input on the deliminator, defaults to newlines.
+  Takes a Slime template as a string as well as a set of bindings, and renders
+  the resulting HTML.
 
-  ## Examples
-      iex> Slime.Renderer.tokenize("div\\nspan")
-      ["div", "span"]
+  Note that this method of rendering is substantially slower than rendering
+  precompiled templates created with Slime.function_from_file/5 and
+  Slime.function_from_string/5.
   """
-  def tokenize(input, delim \\ "\n") do
-    String.split(input, delim)
+  def render(slime, bindings \\ []) do
+    slime
+    |> unquote(__MODULE__).precompile
+    |> EEx.eval_string(bindings)
   end
 
   defmacro __using__([]) do
     quote do
-      import unquote __MODULE__
-      import Slime.Parser
-      import Slime.Compiler
-      import Slime.Tree
-
       require EEx
-
-      @doc """
-      Render Slime markup and bindings as HTML.
-
-      ## Examples
-          iex> defmodule RenderExample do
-          ...>   use Slime.Renderer
-          ...> end
-          iex> RenderExample.render("input.required type=val", val: "text")
-          "<input class=\\"required\\" type=\\"text\\">"
-      """
-      def render(slim, args \\ []) do
-        slim
-        |> precompile
-        |> eval(args)
-      end
+      import unquote(__MODULE__), only: [render: 2, render: 1]
     end
   end
 end

--- a/lib/slime/renderer.ex
+++ b/lib/slime/renderer.ex
@@ -35,11 +35,4 @@ defmodule Slime.Renderer do
     |> unquote(__MODULE__).precompile
     |> EEx.eval_string(bindings)
   end
-
-  defmacro __using__([]) do
-    quote do
-      require EEx
-      import unquote(__MODULE__), only: [render: 2, render: 1]
-    end
-  end
 end

--- a/test/fixtures/app3_private.slime
+++ b/test/fixtures/app3_private.slime
@@ -1,0 +1,2 @@
+= Enum.map n, fn x ->
+  = x

--- a/test/fixtures/app3_public.slime
+++ b/test/fixtures/app3_public.slime
@@ -1,0 +1,3 @@
+div
+  ' What's up
+  = name

--- a/test/integration/app_test.exs
+++ b/test/integration/app_test.exs
@@ -1,0 +1,67 @@
+defmodule Integration.AppTest do
+  use ExUnit.Case
+
+  defmodule App1 do
+    def render do
+      slime = """
+      h1
+        ' Hello,
+        = name
+        | !
+      """
+      Slime.render(slime, name: "world")
+    end
+  end
+
+  test "Slime.render/2" do
+    assert App1.render == "<h1>Hello, world!</h1>"
+  end
+
+
+  defmodule App2 do
+    require Slime
+
+    slime = """
+    h1 Not secret:
+      = word
+    """
+    Slime.function_from_string :def, :public, slime, [:word]
+
+    slime = """
+    h1 Secret:
+      = word
+    """
+    Slime.function_from_string :defp, :priv, slime, [:word]
+
+    def private(x), do: priv(x)
+  end
+
+  test "Slime.function_from_string/5 def" do
+    assert App2.public("Hi!") == "<h1>Not secret:Hi!</h1>"
+  end
+
+  test "Slime.function_from_string/5 defp" do
+    assert App2.private("Eep!") == "<h1>Secret:Eep!</h1>"
+  end
+
+
+  defmodule App3 do
+    require Slime
+
+    file = "test/fixtures/app3_public.slime"
+    Slime.function_from_file :def, :public, file, [:name]
+
+    file = "test/fixtures/app3_private.slime"
+    Slime.function_from_file :defp, :priv, file, [:n]
+
+    def private(x), do: priv(x)
+  end
+
+  test "Slime.function_from_file/5 def" do
+    assert App3.public("doc?") == "<div>What's up doc?</div>"
+  end
+
+  test "Slime.function_from_file/5 defp" do
+    assert App3.private(1..3) == "123"
+  end
+end

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -2,7 +2,7 @@ defmodule RendererTest do
   use ExUnit.Case, async: true
   doctest Slime.Renderer
 
-  use Slime.Renderer
+  import Slime, only: [render: 1, render: 2]
 
   @slime """
   doctype html

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -46,11 +46,7 @@ defmodule RendererTest do
   """ |> String.replace("\n", "")
 
   test "precompiles eex template" do
-    assert precompile(@slime) == @eex
-  end
-
-  test "evaluates eex templates" do
-    assert eval(@eex, site_title: "Website Title") == @html
+    assert Slime.Renderer.precompile(@slime) == @eex
   end
 
   test "render html" do

--- a/test/rendering/attributes_test.exs
+++ b/test/rendering/attributes_test.exs
@@ -1,6 +1,7 @@
 defmodule RenderAttributesTest do
   use ExUnit.Case, async: true
-  use Slime.Renderer
+
+  import Slime, only: [render: 1, render: 2]
 
   test "attributes values can be variables" do
     slime = """

--- a/test/rendering/comments_test.exs
+++ b/test/rendering/comments_test.exs
@@ -1,6 +1,7 @@
 defmodule RenderCommentsTest do
   use ExUnit.Case, async: true
-  use Slime.Renderer
+
+  import Slime, only: [render: 1]
 
   test "lines started with / are commented out" do
     slime = """

--- a/test/rendering/elixir_test.exs
+++ b/test/rendering/elixir_test.exs
@@ -1,8 +1,8 @@
 defmodule RenderElixirTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO, only: [capture_io: 1]
 
-  alias Slime.Renderer, as: R
+  import ExUnit.CaptureIO, only: [capture_io: 1]
+  import Slime,            only: [render: 1, render: 2]
 
   test "- evalutes Elixir but does not insert the result" do
     slime = """
@@ -10,7 +10,7 @@ defmodule RenderElixirTest do
     - _ = "Hi"
     """
     captured = capture_io fn ->
-      assert R.render(slime) == ""
+      assert render(slime) == ""
     end
     assert captured == "Hello\n"
   end
@@ -19,21 +19,21 @@ defmodule RenderElixirTest do
     slime = """
     = 1 + 1
     """
-    assert R.render(slime) == "2"
+    assert render(slime) == "2"
   end
 
   test "= can be used inside an element (space before)" do
     slime = """
     div = 1 + 1
     """
-    assert R.render(slime) == "<div>2</div>"
+    assert render(slime) == "<div>2</div>"
   end
 
   test "= can be used inside an element (no space before)" do
     slime = """
     div= 1 + 1
     """
-    assert R.render(slime) == "<div>2</div>"
+    assert render(slime) == "<div>2</div>"
   end
 
   test "if/else can be used in templates" do
@@ -43,10 +43,8 @@ defmodule RenderElixirTest do
     - else
       h2 Goodbye!
     """
-    assert R.precompile(slime) ==
-      ~s(<%= if meta do %><h1>Hello!</h1><% else %><h2>Goodbye!</h2><% end %>)
-    assert R.render(slime, meta: true)  == ~s(<h1>Hello!</h1>)
-    assert R.render(slime, meta: false) == ~s(<h2>Goodbye!</h2>)
+    assert render(slime, meta: true)  == ~s(<h1>Hello!</h1>)
+    assert render(slime, meta: false) == ~s(<h2>Goodbye!</h2>)
   end
 
   test "unless/else can be used in templates" do
@@ -56,10 +54,8 @@ defmodule RenderElixirTest do
     - else
       h2 Goodbye!
     """
-    assert R.precompile(slime) ==
-      ~s(<%= unless meta do %><h1>Hello!</h1><% else %><h2>Goodbye!</h2><% end %>)
-    assert R.render(slime, meta: true) == ~s(<h2>Goodbye!</h2>)
-    assert R.render(slime, meta: false)  == ~s(<h1>Hello!</h1>)
+    assert render(slime, meta: true) == ~s(<h2>Goodbye!</h2>)
+    assert render(slime, meta: false)  == ~s(<h1>Hello!</h1>)
   end
 
   test "render lines with 'do'" do

--- a/test/rendering/elixir_test.exs
+++ b/test/rendering/elixir_test.exs
@@ -1,7 +1,8 @@
 defmodule RenderElixirTest do
   use ExUnit.Case, async: true
-  use Slime.Renderer
   import ExUnit.CaptureIO, only: [capture_io: 1]
+
+  alias Slime.Renderer, as: R
 
   test "- evalutes Elixir but does not insert the result" do
     slime = """
@@ -9,7 +10,7 @@ defmodule RenderElixirTest do
     - _ = "Hi"
     """
     captured = capture_io fn ->
-      assert render(slime) == ""
+      assert R.render(slime) == ""
     end
     assert captured == "Hello\n"
   end
@@ -18,21 +19,21 @@ defmodule RenderElixirTest do
     slime = """
     = 1 + 1
     """
-    assert render(slime) == "2"
+    assert R.render(slime) == "2"
   end
 
   test "= can be used inside an element (space before)" do
     slime = """
     div = 1 + 1
     """
-    assert render(slime) == "<div>2</div>"
+    assert R.render(slime) == "<div>2</div>"
   end
 
   test "= can be used inside an element (no space before)" do
     slime = """
     div= 1 + 1
     """
-    assert render(slime) == "<div>2</div>"
+    assert R.render(slime) == "<div>2</div>"
   end
 
   test "if/else can be used in templates" do
@@ -42,9 +43,10 @@ defmodule RenderElixirTest do
     - else
       h2 Goodbye!
     """
-    assert precompile(slime) == ~s(<%= if meta do %><h1>Hello!</h1><% else %><h2>Goodbye!</h2><% end %>)
-    assert render(slime, meta: true)  == ~s(<h1>Hello!</h1>)
-    assert render(slime, meta: false) == ~s(<h2>Goodbye!</h2>)
+    assert R.precompile(slime) ==
+      ~s(<%= if meta do %><h1>Hello!</h1><% else %><h2>Goodbye!</h2><% end %>)
+    assert R.render(slime, meta: true)  == ~s(<h1>Hello!</h1>)
+    assert R.render(slime, meta: false) == ~s(<h2>Goodbye!</h2>)
   end
 
   test "unless/else can be used in templates" do
@@ -54,9 +56,10 @@ defmodule RenderElixirTest do
     - else
       h2 Goodbye!
     """
-    assert precompile(slime) == ~s(<%= unless meta do %><h1>Hello!</h1><% else %><h2>Goodbye!</h2><% end %>)
-    assert render(slime, meta: true) == ~s(<h2>Goodbye!</h2>)
-    assert render(slime, meta: false)  == ~s(<h1>Hello!</h1>)
+    assert R.precompile(slime) ==
+      ~s(<%= unless meta do %><h1>Hello!</h1><% else %><h2>Goodbye!</h2><% end %>)
+    assert R.render(slime, meta: true) == ~s(<h2>Goodbye!</h2>)
+    assert R.render(slime, meta: false)  == ~s(<h1>Hello!</h1>)
   end
 
   test "render lines with 'do'" do

--- a/test/rendering/text_test.exs
+++ b/test/rendering/text_test.exs
@@ -1,6 +1,7 @@
 defmodule RenderTextTest do
   use ExUnit.Case, async: true
-  use Slime.Renderer
+
+  import Slime, only: [render: 1, render: 2]
 
   test "elements can have text content" do
     assert render("span Hi there!") == "<span>Hi there!</span>"

--- a/test/rendering/whitespace_test.exs
+++ b/test/rendering/whitespace_test.exs
@@ -1,6 +1,7 @@
 defmodule RenderWhitespaceTest do
   use ExUnit.Case, async: true
-  use Slime.Renderer
+
+  import Slime, only: [render: 1]
 
   test "> inserts a space after the element" do
     assert render(~s(a> href="test" text)) == ~s(<a href="test">text</a> )


### PR DESCRIPTION
I've added integration test coving our public API as our current tests don't verify that these work.

I think it's unclear where the responsibilities and dependencies lie for the various modules at the moment, so I'm going to try and make this clearer by reducing the use of imports and function injection and using alias and defdelegate instead.
