### PR TITLE
No longer convert tags to atoms

### DIFF
--- a/lib/slime/compiler.ex
+++ b/lib/slime/compiler.ex
@@ -6,7 +6,7 @@ defmodule Slime.Compiler do
   @void_elements ~w(
     area br col doctype embed hr img input link meta base param
     keygen source menuitem track wbr
-  )a
+  )
 
   def compile(tree) do
     tree

--- a/lib/slime/parser.ex
+++ b/lib/slime/parser.ex
@@ -190,8 +190,8 @@ defmodule Slime.Parser do
     parts = Regex.named_captures(@tag_regex, line)
 
     tag = case parts["tag"] do
-            "" -> :div
-            tag -> String.to_atom(tag)
+            "" -> "div"
+            tag -> tag
           end
 
     spaces = %{}

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -78,14 +78,14 @@ defmodule CompilerTest do
   test "renders boolean attributes" do
     tree = [
       %Branch{
-        type: :input,
+        type: "input",
         attributes: [class: ["class"],
         required: {:eex, content: "true"}]}
     ]
     assert Compiler.compile(tree) == ~s(<input class="class" required>)
     tree = [
       %Branch{
-        type: :input,
+        type: "input",
         attributes: [class: ["class"],
         required: {:eex, content: "false"}]}
     ]

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -6,27 +6,27 @@ defmodule ParserTest do
   test "parses simple nesting" do
     parsed = ["#id.class", "  p", "    | Hello World"] |> Parser.parse_lines
     assert parsed == [
-      {0, {:div, attributes: [class: "class", id: "id"], children: [], spaces: %{}, close: false}},
-      {2, {:p, attributes: [], children: [], spaces: %{}, close: false}},
+      {0, {"div", attributes: [class: "class", id: "id"], children: [], spaces: %{}, close: false}},
+      {2, {"p", attributes: [], children: [], spaces: %{}, close: false}},
       {4, "Hello World"}
     ]
 
     parsed = ["#id.class","  p Hello World"] |> Parser.parse_lines
     assert parsed == [
-      {0, {:div, attributes: [class: "class", id: "id"], children: [], spaces: %{}, close: false}},
-      {2, {:p, attributes: [], children: ["Hello World"], spaces: %{}, close: false}}
+      {0, {"div", attributes: [class: "class", id: "id"], children: [], spaces: %{}, close: false}},
+      {2, {"p", attributes: [], children: ["Hello World"], spaces: %{}, close: false}}
     ]
   end
 
   test "parses css classes with dashes" do
-    {_, {:div, opts}} = ".my-css-class test"
+    {_, {"div", opts}} = ".my-css-class test"
                          |> Parser.parse_line
     assert opts[:attributes][:class] == "my-css-class"
     assert opts[:children] == ["test"]
   end
 
   test "parses attributes" do
-    {_, {:meta, opts}} = ~S(meta name=variable content="one two")
+    {_, {"meta", opts}} = ~S(meta name=variable content="one two")
                          |> Parser.parse_line
 
     assert opts[:attributes] == [
@@ -35,14 +35,14 @@ defmodule ParserTest do
   end
 
   test "parses attributes with wrappers" do
-    {_, {:meta, opts}} = ~s[meta(name=other content="one two")]
+    {_, {"meta", opts}} = ~s[meta(name=other content="one two")]
                          |> Parser.parse_line
 
     assert opts[:attributes] == [
       name: {:eex, content: "other", inline: true}, content: "one two"
     ]
 
-    {_, {:meta, opts}} = ~S(meta {name=variable content="one two"})
+    {_, {"meta", opts}} = ~S(meta {name=variable content="one two"})
                          |> Parser.parse_line
 
     assert opts[:attributes] == [
@@ -51,61 +51,61 @@ defmodule ParserTest do
   end
 
   test "parses boolean attributes" do
-    {_, {:input, opts}} = ~s[input (type="text" required=true)]
+    {_, {"input", opts}} = ~s[input (type="text" required=true)]
                           |> Parser.parse_line
 
     assert opts[:attributes] == [type: "text", required: {:eex, content: "true", inline: true}]
 
-    {_, {:input, opts}} = ~s[input (type="text" required)]
+    {_, {"input", opts}} = ~s[input (type="text" required)]
                           |> Parser.parse_line
 
     assert opts[:attributes] == [type: "text", required: {:eex, content: "true", inline: true}]
   end
 
   test "parses attributes with interpolation" do
-    {_, {:meta, opts}} = ~S(meta content="one#{two}") |> Parser.parse_line
+    {_, {"meta", opts}} = ~S(meta content="one#{two}") |> Parser.parse_line
 
     assert opts[:attributes] == [content: {:eex, content: ~S("one#{two}"), inline: true}]
   end
 
   test "parses attributes with qutation inside interoplation correctly" do
-    {_, {:meta, opts}} = ~S[meta content="one#{two("three")}"] |> Parser.parse_line
+    {_, {"meta", opts}} = ~S[meta content="one#{two("three")}"] |> Parser.parse_line
 
     assert opts[:attributes] == [content: {:eex, content: ~S["one#{two("three")}"], inline: true}]
   end
 
   test "parses attributes with tuples inside interoplation correctly" do
-    {_, {:meta, opts}} = ~S[meta content="one#{two({"three" "four"})}"] |> Parser.parse_line
+    {_, {"meta", opts}} = ~S[meta content="one#{two({"three" "four"})}"] |> Parser.parse_line
 
     assert opts[:attributes] == [content: {:eex, content: ~S["one#{two({"three" "four"})}"], inline: true}]
   end
 
   test "parses attributes with elixir code" do
-    {_, {:meta, opts}} = ~S(meta content=@user.name) |> Parser.parse_line
+    {_, {"meta", opts}} = ~S(meta content=@user.name) |> Parser.parse_line
     assert opts[:attributes] == [content: {:eex, content: ~S(@user.name), inline: true}]
 
-    {_, {:meta, opts}} = ~S(meta content=user.name) |> Parser.parse_line
+    {_, {"meta", opts}} = ~S(meta content=user.name) |> Parser.parse_line
     assert opts[:attributes] == [content: {:eex, content: ~S(user.name), inline: true}]
 
-    {_, {:meta, opts}} = ~S(meta content=user["name"]) |> Parser.parse_line
+    {_, {"meta", opts}} = ~S(meta content=user["name"]) |> Parser.parse_line
     assert opts[:attributes] == [content: {:eex, content: ~S(user["name"]), inline: true}]
   end
 
   test "parses attributes and inline children" do
-    {_, {:div, opts}} = ~S(div id="id" text content)
+    {_, {"div", opts}} = ~S(div id="id" text content)
                         |> Parser.parse_line
 
     assert opts[:attributes] == [id: "id"]
     assert opts[:children] == ["text content"]
 
-    {_, {:div, opts}} = ~S(div id="id" = elixir_func)
+    {_, {"div", opts}} = ~S(div id="id" = elixir_func)
                         |> Parser.parse_line
 
     assert opts[:children] == [{:eex, content: "elixir_func", inline: true}]
   end
 
   test "parses inline children with interpolation" do
-    {_, {:div, opts}} = "div text \#{content}" |> Parser.parse_line
+    {_, {"div", opts}} = "div text \#{content}" |> Parser.parse_line
 
     assert opts[:children] == [{:eex, content: ~S("text #{content}"), inline: true}]
   end
@@ -149,8 +149,8 @@ defmodule ParserTest do
   test "parses final newline properly" do
     parsed = ["#id.class", "  p", "    | Hello World", ""] |> Parser.parse_lines
     assert parsed == [
-      {0, {:div, attributes: [class: "class", id: "id"], children: [], spaces: %{}, close: false}},
-      {2, {:p, attributes: [], children: [], spaces: %{}, close: false}},
+      {0, {"div", attributes: [class: "class", id: "id"], children: [], spaces: %{}, close: false}},
+      {2, {"p", attributes: [], children: [], spaces: %{}, close: false}},
       {4, "Hello World"}
     ]
   end
@@ -180,7 +180,7 @@ defmodule ParserTest do
   end
 
   test "parses closed tags" do
-    {_, {:img, opts}} = ~S(img id="id"/) |> Parser.parse_line
+    {_, {"img", opts}} = ~S(img id="id"/) |> Parser.parse_line
 
     assert opts[:close]
   end


### PR DESCRIPTION
RFC @lpil — With this change we no longer convert all tags to atoms, first step at satisfying #82.  The attributes will take a little more work but this should be good to go now.
