### PR TITLE
Compile performance optimizations

### DIFF
--- a/bench/performance_bottlenecks_bench.exs
+++ b/bench/performance_bottlenecks_bench.exs
@@ -1,0 +1,15 @@
+defmodule PerformanceBottlenecksBench do
+  use Benchfella
+
+  @slime ~S(h2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do #{"eiusmod"})
+  bench "interpolation performance on long lines" do
+    Slime.Parser.parse_line(@slime)
+  end
+
+  @slime """
+  a.social__link.facebook itemprop="sameAs" href="http://www.facebook.com/test" title="Facebook" target="_blank"
+  """
+  bench "inline tag split performance on attributes with :" do
+    Slime.Preprocessor.process(@slime)
+  end
+end

--- a/lib/slime/parser.ex
+++ b/lib/slime/parser.ex
@@ -16,6 +16,8 @@ defmodule Slime.Parser do
   @attr_delim_regex ~r/[ ]+(?=([^"]*"[^"]*")*[^"]*$)/
   @attr_group_regex ~r/(?:\s*[\w-]+\s*=\s*(?:[^\s"'][^\s]+[^\s"']|"(?:(?<z>\{(?:[^{}]|\g<z>)*\})|[^"])*"|'[^']*'))*/
   @tag_regex ~r/\A(?<tag>\w*)(?:#(?<id>[\w-]*))?(?<css>(?:\.[\w-]*)*)?(?<leading_space>\<)?(?<trailing_space>\>)?/
+  r = ~r/(^|\G)(?:\\.|[^#]|#(?!\{)|(?<pn>#\{(?:[^"}]++|"(?:\\.|[^"#]|#(?!\{)|(?&pn))*")*\}))*?\K"/u
+  @quote_outside_interpolation_regex r
   @verbatim_text_regex ~r/^(\s*)([#{@content}#{@preserved}])\s?/
 
   @merge_attrs %{class: " "}
@@ -93,7 +95,7 @@ defmodule Slime.Parser do
 
   defp parse_eex_string(input) do
     if String.contains?(input, "\#{") do
-      script = "\"#{String.replace(input, ~r/^(?<z>[^{}]*|\#\{\g<z>*\})*\K"/, "\\\\\"")}\""
+      script = ~s("#{String.replace(input, @quote_outside_interpolation_regex, ~S(\\"))}")
       {:eex, content: script, inline: true}
     else
       input

--- a/lib/slime/preprocessor.ex
+++ b/lib/slime/preprocessor.ex
@@ -25,12 +25,11 @@ defmodule Slime.Preprocessor do
     String.replace(document, ~r/\n+\z/m, "")
   end
 
-  def split_into_lines(document) do
+  defp split_into_lines(document) do
     String.split(document, "\n")
   end
 
-
-  @inline_tag_regex ~r/\A(?<indent>\s*)(?<short_tag>(?:[\.#]?[\w-]*)+):\W*(?<inline_tag>.*)/
+  @inline_tag_regex ~r/\A(?<indent>\s*+)(?<short_tag>(?:[\.#]?[\w-]+)++):\W*(?<inline_tag>.*)/
 
   defp split_inline_tags(line) do
     @inline_tag_regex

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -122,6 +122,14 @@ defmodule ParserTest do
     assert opts[:content] == ~s(" text \#{content}\n")
   end
 
+  test "interpolation performance on long lines" do
+    slime = ~S(h2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do #{"eiusmod"})
+    {time, _} = :timer.tc(fn ->
+      Parser.parse_line(slime)
+    end)
+    assert time < 1000
+  end
+
   test "parses doctype" do
     {_, {:doctype, doc_string}} = "doctype html"
                          |> Parser.parse_line
@@ -141,9 +149,9 @@ defmodule ParserTest do
   end
 
   test "quote inline html with interpolation" do
-    {_, {:eex, opts}} = Parser.parse_line(~S(<h3>Text" #{"elixir_string"}</h3>))
+    {_, {:eex, opts}} = Parser.parse_line(~S(<h3>Text""" #{"elixir_string"} "</h3>))
     assert opts[:inline]
-    assert opts[:content] == ~S["<h3>Text\" #{"elixir_string"}</h3>"]
+    assert opts[:content] == ~S["<h3>Text\"\"\" #{"elixir_string"} \"</h3>"]
   end
 
   test "parses final newline properly" do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -122,14 +122,6 @@ defmodule ParserTest do
     assert opts[:content] == ~s(" text \#{content}\n")
   end
 
-  test "interpolation performance on long lines" do
-    slime = ~S(h2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do #{"eiusmod"})
-    {time, _} = :timer.tc(fn ->
-      Parser.parse_line(slime)
-    end)
-    assert time < 1000
-  end
-
   test "parses doctype" do
     {_, {:doctype, doc_string}} = "doctype html"
                          |> Parser.parse_line

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -57,4 +57,14 @@ defmodule Slime.PreprocessorTest do
       "    a href='/b' B link",
     ]
   end
+
+  test "inline tag split performance on attributes with :" do
+    slim = """
+    a.social__link.facebook itemprop="sameAs" href="http://www.facebook.com/test" title="Facebook" target="_blank"
+    """
+    {time, _} = :timer.tc(fn ->
+      process(slim)
+    end)
+    assert time < 1000
+  end
 end

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -57,14 +57,4 @@ defmodule Slime.PreprocessorTest do
       "    a href='/b' B link",
     ]
   end
-
-  test "inline tag split performance on attributes with :" do
-    slim = """
-    a.social__link.facebook itemprop="sameAs" href="http://www.facebook.com/test" title="Facebook" target="_blank"
-    """
-    {time, _} = :timer.tc(fn ->
-      process(slim)
-    end)
-    assert time < 1000
-  end
 end


### PR DESCRIPTION
Optimised regular expressions for interpolation and inline tags.
Some performance tests are provided, but I am not sure if I should keep them in repo.
Each test case took more than 200ms on my computer.
Any thoughts?
