### PR TITLE
Adds support for dashes in tag names

### DIFF
--- a/lib/slime/parser.ex
+++ b/lib/slime/parser.ex
@@ -15,7 +15,7 @@ defmodule Slime.Parser do
 
   @attr_delim_regex ~r/[ ]+(?=([^"]*"[^"]*")*[^"]*$)/
   @attr_group_regex ~r/(?:\s*[\w-]+\s*=\s*(?:[^\s"'][^\s]+[^\s"']|"(?:(?<z>\{(?:[^{}]|\g<z>)*\})|[^"])*"|'[^']*'))*/
-  @tag_regex ~r/\A(?<tag>\w*)(?:#(?<id>[\w-]*))?(?<css>(?:\.[\w-]*)*)?(?<leading_space>\<)?(?<trailing_space>\>)?/
+  @tag_regex ~r/\A(?<tag>[\w-]*)(?:#(?<id>[\w-]*))?(?<css>(?:\.[\w-]*)*)?(?<leading_space>\<)?(?<trailing_space>\>)?/
   r = ~r/(^|\G)(?:\\.|[^#]|#(?!\{)|(?<pn>#\{(?:[^"}]++|"(?:\\.|[^"#]|#(?!\{)|(?&pn))*")*\}))*?\K"/u
   @quote_outside_interpolation_regex r
   @verbatim_text_regex ~r/^(\s*)([#{@content}#{@preserved}])\s?/

--- a/test/rendering/tag_test.exs
+++ b/test/rendering/tag_test.exs
@@ -1,0 +1,9 @@
+defmodule TagTest do
+  use ExUnit.Case, async: true
+
+  import Slime, only: [render: 1]
+
+  test "dashed-strings can be used as tags" do
+    assert render(~s(my-component text)) == ~s(<my-component>text</my-component>)
+  end
+end


### PR DESCRIPTION
Thanks for the work on this library! I was wondering if you would be open to expanding what slime will accept:

`my-component text` -> `<my-component>text</my-component>`

In my case, this would help me work with some angular directives that bind to specific DOM elements by tag. FWIW, ruby's slim supports this case.
