### PR TITLE
Add support for multi-line elixir statements

### DIFF
--- a/test/parser/multiline_elixir_test.exs
+++ b/test/parser/multiline_elixir_test.exs
@@ -1,0 +1,52 @@
+defmodule ParserMultilineElixirTest do
+  use ExUnit.Case
+  alias Slime.Parser
+
+  test "= allows multi-line elixir expressions ending with backslash" do
+    lines = [
+      "= very_long_method_name \\",
+      "        another_expression \\",
+      "     Final_expression"
+    ]
+    parsed  = Parser.parse_lines(lines)
+    content = lines |> Enum.join("\n") |> String.lstrip(?=) |> String.lstrip
+
+    assert parsed == [{0, {:eex, [content: content, inline: true]}}]
+  end
+
+  test "= allows multi-line elixir method arguments" do
+    lines = [
+      "=method_name param1,",
+      "             param2,",
+      "             param3"
+    ]
+    parsed  = Parser.parse_lines(lines)
+    content = lines |> Enum.join("\n") |> String.lstrip(?=) |> String.lstrip
+
+    assert parsed == [{0, {:eex, [content: content, inline: true]}}]
+  end
+
+  test "- allows multi-line elixir expressions ending with backslash" do
+    lines = [
+      "- very_long_method_name \\",
+      "        another_expression \\",
+      "     Final_expression"
+    ]
+    parsed  = Parser.parse_lines(lines)
+    content = lines |> Enum.join("\n") |> String.lstrip(?-) |> String.lstrip
+
+    assert parsed == [{0, {:eex, [content: content, inline: false]}}]
+  end
+
+  test "- allows multi-line elixir method arguments" do
+    lines = [
+      "-method_name param1,",
+      "             param2,",
+      "             param3"
+    ]
+    parsed  = Parser.parse_lines(lines)
+    content = lines |> Enum.join("\n") |> String.lstrip(?-) |> String.lstrip
+
+    assert parsed == [{0, {:eex, [content: content, inline: false]}}]
+  end
+end


### PR DESCRIPTION
From the slim documentation:

> If your ruby code needs to use multiple lines, append a backslash \ at the end of the lines. If your line ends with comma , (e.g because of a method call) you don't need the additional backslash before the line break.

This PR should enable this for slime.
