### PR TITLE
Fixed warnings in Elixir 1.4.0

### DIFF
--- a/lib/slime.ex
+++ b/lib/slime.ex
@@ -37,7 +37,7 @@ defmodule Slime do
       Sample.sample(1, 2) #=> "3"
   """
   defmacro function_from_file(kind, name, file, args \\ [], opts \\ []) do
-    quote bind_quoted: binding do
+    quote bind_quoted: binding() do
       require EEx
       eex = file |> File.read! |> Renderer.precompile
       EEx.function_from_string(kind, name, eex, args, opts)
@@ -59,7 +59,7 @@ defmodule Slime do
       "3"
   """
   defmacro function_from_string(kind, name, source, args \\ [], opts \\ []) do
-    quote bind_quoted: binding do
+    quote bind_quoted: binding() do
       require EEx
       eex = source |> Renderer.precompile
       EEx.function_from_string(kind, name, eex, args, opts)

--- a/lib/slime/doctype.ex
+++ b/lib/slime/doctype.ex
@@ -15,18 +15,15 @@ defmodule Slime.Doctype do
   def for("basic"),
     do: ~S[<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">]
 
-  @lint false
   def for("frameset"),
     do: ~S[<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">]
 
-  @lint false
   def for("mobile"),
     do: ~S[<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">]
 
   def for("strict"),
     do: ~S[<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">]
 
-  @lint false
   def for("transitional"),
     do: ~S[<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">]
 

--- a/lib/slime/parser.ex
+++ b/lib/slime/parser.ex
@@ -19,7 +19,7 @@ defmodule Slime.Parser do
   @attr_group_regex ~r/(?:\s*[\w-]+\s*=\s*(?:[^"'].*?(?= [^ "']+=|$)|"(?:(?<z>\{(?:[^{}]|\g<z>)*\})|[^"])*"|'[^']*'))*/
 
   @parse_line_split_regexes @attr_list_delims
-  |> Dict.keys
+  |> Map.keys
   |> Enum.map(&("|\\" <> &1))
   @parse_line_split_regexes ["\\s|="] ++ @parse_line_split_regexes
   @parse_line_split_regex @parse_line_split_regexes
@@ -34,7 +34,6 @@ defmodule Slime.Parser do
   @eex_line_regex ~r/^(\s*)(-|=|==)\s*(.*?)$/
 
   @merge_attrs %{class: " "}
-  @indent 2
 
   def parse_lines(lines, acc \\ [])
 
@@ -142,7 +141,7 @@ defmodule Slime.Parser do
 
   defp parse_attributes(line) do
     delim = String.first(line)
-    if Dict.has_key?(@attr_list_delims , delim) do
+    if Map.has_key?(@attr_list_delims , delim) do
       line = String.slice(line, 1..-1)
       parse_wrapped_attributes(line, @attr_list_delims[delim])
     else
@@ -236,8 +235,8 @@ defmodule Slime.Parser do
           end
 
     spaces = %{}
-    spaces = if parts["leading_space"] != "", do: Dict.put(spaces, :leading, true), else: spaces
-    spaces = if parts["trailing_space"] != "", do: Dict.put(spaces, :trailing, true), else: spaces
+    spaces = if parts["leading_space"] != "", do: Map.put(spaces, :leading, true), else: spaces
+    spaces = if parts["trailing_space"] != "", do: Map.put(spaces, :trailing, true), else: spaces
 
     case Regex.named_captures(@id_regex, parts["css"]) do
       nil ->

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Slime.Mixfile do
   def project do
     [app: :slime,
      build_embedded: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      description: """
      An Elixir library for rendering Slim-like templates.
      """,

--- a/test/rendering/attributes_test.exs
+++ b/test/rendering/attributes_test.exs
@@ -75,7 +75,7 @@ defmodule RenderAttributesTest do
       Slime.function_from_string(:def, :pre_render, @slime, [], engine: Phoenix.HTML.Engine)
 
       def render do
-        pre_render |> Phoenix.HTML.Safe.to_iodata |> IO.iodata_to_binary
+        pre_render() |> Phoenix.HTML.Safe.to_iodata |> IO.iodata_to_binary
       end
     end
 


### PR DESCRIPTION
* Added missing parenthesis on methods with no args
* Removed `@lint false` some places. Credo still runs
* Removed unused `@indent` in parser
* Changed deprecated `Dict` function calls to `Map`