### PR TITLE
Support leading/trailing spaces for EEX with =<, => and =<>

### DIFF
--- a/lib/slime/compiler.ex
+++ b/lib/slime/compiler.ex
@@ -60,9 +60,11 @@ defmodule Slime.Compiler do
   end
 
 
-  defp open(_, %EExNode{content: code, attributes: attrs}) do
+  defp open(_, %EExNode{content: code, attributes: attrs, spaces: spaces}) do
+    prefix = if spaces[:leading], do: " "
+    suffix = if spaces[:trailing], do: " "
     inline = if attrs[:inline], do: "=", else: ""
-    "<%#{inline} #{code} %>\r"
+    "#{prefix}<%#{inline} #{code} %>#{suffix}\r"
   end
   defp open(_, %HTMLNode{tag: :html_comment}) do
     "<!--"

--- a/lib/slime/tree.ex
+++ b/lib/slime/tree.ex
@@ -55,10 +55,12 @@ defmodule Slime.Tree do
   defp to_branch({:eex, attrs}) do
     children = Keyword.get(attrs, :children, [])
     inline = Keyword.get(attrs, :inline, false)
+    spaces = Keyword.get(attrs, :spaces, %{})
     %EExNode{
       attributes: [inline: inline],
       children: children,
-      content: attrs[:content]
+      content: attrs[:content],
+      spaces: spaces
     }
   end
   defp to_branch({tag, attrs}) do

--- a/lib/slime/tree/eex_node.ex
+++ b/lib/slime/tree/eex_node.ex
@@ -5,5 +5,6 @@ defmodule Slime.Tree.EExNode do
 
   defstruct attributes: [],
             children: [],
-            content: ""
+            content: "",
+            spaces: %{}
 end

--- a/test/parser/multiline_elixir_test.exs
+++ b/test/parser/multiline_elixir_test.exs
@@ -11,7 +11,7 @@ defmodule ParserMultilineElixirTest do
     parsed  = Parser.parse_lines(lines)
     content = lines |> Enum.join("\n") |> String.lstrip(?=) |> String.lstrip
 
-    assert parsed == [{0, {:eex, [content: content, inline: true]}}]
+    assert parsed == [{0, {:eex, [content: content, inline: true, spaces: %{}]}}]
   end
 
   test "= allows multi-line elixir method arguments" do
@@ -23,7 +23,7 @@ defmodule ParserMultilineElixirTest do
     parsed  = Parser.parse_lines(lines)
     content = lines |> Enum.join("\n") |> String.lstrip(?=) |> String.lstrip
 
-    assert parsed == [{0, {:eex, [content: content, inline: true]}}]
+    assert parsed == [{0, {:eex, [content: content, inline: true, spaces: %{}]}}]
   end
 
   test "- allows multi-line elixir expressions ending with backslash" do
@@ -35,7 +35,7 @@ defmodule ParserMultilineElixirTest do
     parsed  = Parser.parse_lines(lines)
     content = lines |> Enum.join("\n") |> String.lstrip(?-) |> String.lstrip
 
-    assert parsed == [{0, {:eex, [content: content, inline: false]}}]
+    assert parsed == [{0, {:eex, [content: content, inline: false, spaces: %{}]}}]
   end
 
   test "- allows multi-line elixir method arguments" do
@@ -47,6 +47,6 @@ defmodule ParserMultilineElixirTest do
     parsed  = Parser.parse_lines(lines)
     content = lines |> Enum.join("\n") |> String.lstrip(?-) |> String.lstrip
 
-    assert parsed == [{0, {:eex, [content: content, inline: false]}}]
+    assert parsed == [{0, {:eex, [content: content, inline: false, spaces: %{}]}}]
   end
 end

--- a/test/rendering/elixir_test.exs
+++ b/test/rendering/elixir_test.exs
@@ -36,6 +36,33 @@ defmodule RenderElixirTest do
     assert render(slime) == "<div>2</div>"
   end
 
+  test "=> inserts a trailing space" do
+    slime = """
+    | [
+    => 1 + 1
+    | ]
+    """
+    assert render(slime) == "[2 ]"
+  end
+
+  test "=< inserts a leading space" do
+    slime = """
+    | [
+    =< 1 + 1
+    | ]
+    """
+    assert render(slime) == "[ 2]"
+  end
+
+  test "=<> inserts leading and trailing spaces" do
+    slime = """
+    | [
+    =<> 1 + 1
+    | ]
+    """
+    assert render(slime) == "[ 2 ]"
+  end
+
   test "if/else can be used in templates" do
     slime = """
     = if meta do


### PR DESCRIPTION
I came across the lack of support for leading and trailing spaces with EEX nodes today, and noticed that issue #109 was already open. I've had a stab at adding that feature – what do you think?