### PR TITLE
Fix inline nesting

### DIFF
--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -18,6 +18,30 @@ defmodule ParserTest do
     ]
   end
 
+  test "parses inline nesting" do
+    parsed = [".row: .col-lg-12: p Hello World"] |> Parser.parse_lines
+    assert parsed == [
+      {0, {"div",
+           children: [
+             {"div",
+              children: [
+                {"p",
+                 attributes: [],
+                 children: ["Hello World"],
+                 spaces: %{},
+                 close: false}
+              ],
+              attributes: [class: "col-lg-12"],
+              spaces: %{},
+              close: false}
+           ],
+           attributes: [class: "row"],
+           spaces: %{},
+           close: false}
+      }
+    ]
+  end
+
   test "parses css classes with dashes" do
     {_, {"div", opts}} = ".my-css-class test"
                          |> Parser.parse_line

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -112,6 +112,31 @@ defmodule RendererTest do
     """ |> String.replace("\n", "")
   end
 
+  test "render mixed nesting" do
+    slime = ~s"""
+    .wrap: .row: .col-lg-12
+      .box: p One
+      .box: p Two
+    p Three
+    """
+
+    assert render(slime) == """
+    <div class="wrap">
+    <div class="row">
+    <div class="col-lg-12">
+    <div class="box">
+    <p>One</p>
+    </div>
+    <div class="box">
+    <p>Two</p>
+    </div>
+    </div>
+    </div>
+    </div>
+    <p>Three</p>
+    """ |> String.replace("\n", "")
+  end
+
   test "render closed tag (ending with /)" do
     assert render(~s(img src="image.png"/)) == ~s(<img src="image.png"/>)
   end

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -98,6 +98,20 @@ defmodule RendererTest do
     """ |> String.replace("\n", "")
   end
 
+  test "render nested inline html" do
+    slime = ~s"""
+    .row: .col-lg-12: p Hello World
+    """
+
+    assert render(slime) == """
+    <div class="row">
+    <div class="col-lg-12">
+    <p>Hello World</p>
+    </div>
+    </div>
+    """ |> String.replace("\n", "")
+  end
+
   test "render closed tag (ending with /)" do
     assert render(~s(img src="image.png"/)) == ~s(<img src="image.png"/>)
   end

--- a/test/tree_test.exs
+++ b/test/tree_test.exs
@@ -31,4 +31,56 @@ defmodule TreeTest do
 
     assert parsed == expected
   end
+
+  test "creates tree with mixed nesting" do
+    expected = [
+      %HTMLNode{
+        tag: :div,
+        attributes: [class: ~w(wrap)],
+        children: [
+          %HTMLNode{
+            tag: :div,
+            attributes: [class: ~w(row)],
+            children: [
+              %HTMLNode{
+                tag: :div,
+                attributes: [class: ~w(col-lg-12)],
+                children: [
+                  %HTMLNode{
+                    tag: :div,
+                    attributes: [class: ~w(box)],
+                    children: [
+                      %HTMLNode{
+                        tag: :p,
+                        attributes: [],
+                        children: [%TextNode{content: "One"}]}]},
+                  %HTMLNode{
+                    tag: :p,
+                    attributes: [],
+                    children: [%TextNode{content: "Two"}]}]}]}]},
+      %HTMLNode{
+        tag: :p,
+        attributes: [],
+        children: [%TextNode{content: "Three"}]}]
+
+    parsed = [
+      {0, {:div,
+           attributes: [class: ~w(wrap)],
+           children: [
+             {:div,
+              attributes: [class: ~w(row)],
+              children: [
+                {:div,
+                 attributes: [class: ~w(col-lg-12)],
+                 children: []}]}]}},
+      {2, {:div,
+           attributes: [class: ~w(box)],
+           children: [
+             {:p, attributes: [], children: ~w(One)}]}},
+      {2, {:p, attributes: [], children: ~w(Two)}},
+      {0, {:p, attributes: [], children: ~w(Three)}}
+    ] |> Tree.build_tree
+
+    assert parsed == expected
+  end
 end


### PR DESCRIPTION
Currently this:

```slim
.row: .col-lg-12: p Hello World
```

gets compiled into:

```html
<div class="row"><col-lg-12>p Hello World</col-lg-12></div>
```

With this PR it becomes:

```html
<div class="row"><div class="col-lg-12"><p>Hello World</p></div></div>
```