### PR TITLE
Multiline comments

### DIFF
--- a/lib/slime/parser/text_block.ex
+++ b/lib/slime/parser/text_block.ex
@@ -27,12 +27,7 @@ defmodule Slime.Parser.TextBlock do
     text_indent = Enum.find_value(lines, 0,
       fn({indent, line, _}) -> line != "" && indent end)
 
-    {text, is_eex} = Enum.reduce(lines, {"", false},
-      fn ({line_indent, line, is_eex_line}, {text, is_eex}) ->
-        text = if text == "", do: text, else: text <> "\n"
-        leading_space = String.duplicate(" ", line_indent - text_indent)
-        {text <> leading_space <> line, is_eex || is_eex_line}
-      end)
+    {text, is_eex} = insert_line_spacing(lines, text_indent)
 
     text = text <> trailing_whitespace
 
@@ -41,5 +36,14 @@ defmodule Slime.Parser.TextBlock do
     else
       text
     end
+  end
+
+  defp insert_line_spacing(lines, text_indent) do
+    lines |> Enum.reduce({"", false},
+      fn ({line_indent, line, is_eex_line}, {text, is_eex}) ->
+        text = if text == "", do: text, else: text <> "\n"
+        leading_space = String.duplicate(" ", line_indent - text_indent)
+        {text <> leading_space <> line, is_eex || is_eex_line}
+      end)
   end
 end

--- a/lib/slime/parser/text_block.ex
+++ b/lib/slime/parser/text_block.ex
@@ -1,0 +1,36 @@
+defmodule Slime.Parser.TextBlock do
+  @moduledoc "
+  Utilities for parsing text blocks.
+  "
+
+  @doc """
+  Given a text block and its declaration indentation level (see below),
+  produces a {content, is_eex} tuple.
+
+  nested
+    | Text block
+       that spans over multiple lines
+  ---
+   ^
+  declaration indent
+  """
+  def render(lines, decl_indent) do
+    [{first_line_indent, first_line, is_eex_line} | rest] = lines
+
+    text_indent = if first_line == "" do
+      [{indent, _, _} | _] = rest
+      indent
+    else
+      decl_indent + first_line_indent
+    end
+
+    content = [{text_indent, first_line, is_eex_line} | rest]
+
+    Enum.reduce(content, {"", false},
+      fn ({line_indent, line, is_eex_line}, {text, is_eex}) ->
+        text = if text == "", do: text, else: text <> "\n"
+        leading_space = String.duplicate(" ", line_indent - text_indent)
+        {text <> leading_space <> line, is_eex || is_eex_line}
+      end)
+  end
+end

--- a/lib/slime/parser/text_block.ex
+++ b/lib/slime/parser/text_block.ex
@@ -16,19 +16,18 @@ defmodule Slime.Parser.TextBlock do
    ^
   declaration indent
   """
-  def render(lines, decl_indent, trailing_whitespace \\ "") do
-    [{first_line_indent, first_line, is_eex_line} | rest] = lines
-
-    text_indent = if first_line == "" do
-      [{indent, _, _} | _] = rest
-      indent
-    else
-      decl_indent + first_line_indent
+  def render(lines, declaration_indent, trailing_whitespace \\ "") do
+    lines = case lines do
+      [{_, "", _} | rest] -> rest
+      [{relative_indent, first_line, is_eex} | rest] ->
+        first_line_indent = relative_indent + declaration_indent
+        [{first_line_indent, first_line, is_eex} | rest]
     end
 
-    content = [{text_indent, first_line, is_eex_line} | rest]
+    text_indent = Enum.find_value(lines, 0,
+      fn({indent, line, _}) -> line != "" && indent end)
 
-    {text, is_eex} = Enum.reduce(content, {"", false},
+    {text, is_eex} = Enum.reduce(lines, {"", false},
       fn ({line_indent, line, is_eex_line}, {text, is_eex}) ->
         text = if text == "", do: text, else: text <> "\n"
         leading_space = String.duplicate(" ", line_indent - text_indent)

--- a/lib/slime/parser/text_block.ex
+++ b/lib/slime/parser/text_block.ex
@@ -3,9 +3,11 @@ defmodule Slime.Parser.TextBlock do
   Utilities for parsing text blocks.
   "
 
+  import Slime.Parser.Transform, only: [wrap_in_quotes: 1]
+
   @doc """
   Given a text block and its declaration indentation level (see below),
-  produces a {content, is_eex} tuple.
+  produces a string (or a dynamic EEx tuple) that can be inserted into the tree.
 
   nested
     | Text block
@@ -14,7 +16,7 @@ defmodule Slime.Parser.TextBlock do
    ^
   declaration indent
   """
-  def render(lines, decl_indent) do
+  def render(lines, decl_indent, trailing_whitespace \\ "") do
     [{first_line_indent, first_line, is_eex_line} | rest] = lines
 
     text_indent = if first_line == "" do
@@ -26,11 +28,19 @@ defmodule Slime.Parser.TextBlock do
 
     content = [{text_indent, first_line, is_eex_line} | rest]
 
-    Enum.reduce(content, {"", false},
+    {text, is_eex} = Enum.reduce(content, {"", false},
       fn ({line_indent, line, is_eex_line}, {text, is_eex}) ->
         text = if text == "", do: text, else: text <> "\n"
         leading_space = String.duplicate(" ", line_indent - text_indent)
         {text <> leading_space <> line, is_eex || is_eex_line}
       end)
+
+    text = text <> trailing_whitespace
+
+    if is_eex do
+      {:eex, content: wrap_in_quotes(text), inline: true}
+    else
+      text
+    end
   end
 end

--- a/lib/slime/parser/transform.ex
+++ b/lib/slime/parser/transform.ex
@@ -73,7 +73,16 @@ defmodule Slime.Parser.Transform do
   end
 
   def transform(:html_comment, input, _index) do
-    {:html_comment, children: [to_string(Enum.at(input, 2))]}
+    indent = indent_size(input[:indent])
+    decl_indent = indent + String.length(input[:type])
+
+    {text, is_eex} = TextBlock.render(input[:content], decl_indent)
+
+    {indent, {:html_comment, children: [if is_eex do
+      {:eex, content: wrap_in_quotes(text), inline: true}
+    else
+      text
+    end]}}
   end
 
   def transform(:ie_comment, input, _index) do

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -8,10 +8,10 @@ doctype <- space? 'doctype' space (!eol .)+ eol;
 % Also remove dedent from eol definition and modify transforms accordingly
 tags_list <- tag (crlf indent? empty_lines:(space? crlf indent?)* tag:tag dedent*)*;
 
-% NOTE: We have to track leading spaces for verbatim_text, so it handled separately
-tag <- verbatim_text / space? tag_item / blank:(space? &eol);
+% NOTE: Leading whitespace is handled separately for text items
+tag <- text_item / space? tag_item / blank:(space? &eol);
 
-tag_item <- (embedded_engine / comment / inline_html / code / html_tag);
+tag_item <- (embedded_engine / inline_html / code / html_tag);
 
 inline_html <- &'<' text_content;
 
@@ -83,16 +83,15 @@ braces <- '{' (braces / !'}' .)* '}';
 
 interpolation <- '#{' (string / string_with_interpolation / !'}' .)* '}';
 
-comment <- html_comment / ie_comment / code_comment;
+text_item <- verbatim_text / html_comment / space? ie_comment / space? code_comment;
 
-html_comment <- '/!' space? (!eol .)*;
+verbatim_text <- indent:space? type:[|'] content:text_block;
+
+html_comment <- indent:space? type:'/!' content:text_block;
 
 ie_comment <- '/[' condition:(!']' .)+ ']' space? content:(!eol .)*;
 
-% TODO: support multi-line
-code_comment <- '/' (!eol .)*;
-
-verbatim_text <- indent:space? type:[|'] content:text_block;
+code_comment <- '/' text_block;
 
 text_block <- text_block_line (crlf
   indent lines:text_block_nested_lines dedent)?;

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -8,8 +8,8 @@ doctype <- space? 'doctype' space (!eol .)+ eol;
 % Also remove dedent from eol definition and modify transforms accordingly
 tags_list <- tag (crlf indent? empty_lines:(space? crlf indent?)* tag:tag dedent*)*;
 
-% NOTE: Leading whitespace is handled separately for text items
-tag <- text_item / space? tag_item / blank:(space? &eol);
+% NOTE: Leading whitespace is handled separately for comments and verbatim text
+tag <- comment / verbatim_text / space? tag_item / blank:(space? &eol);
 
 tag_item <- (embedded_engine / inline_html / code / html_tag);
 
@@ -83,15 +83,15 @@ braces <- '{' (braces / !'}' .)* '}';
 
 interpolation <- '#{' (string / string_with_interpolation / !'}' .)* '}';
 
-text_item <- verbatim_text / html_comment / space? ie_comment / space? code_comment;
-
-verbatim_text <- indent:space? type:[|'] content:text_block;
+comment <- html_comment / space? ie_comment / space? code_comment;
 
 html_comment <- indent:space? type:'/!' content:text_block;
 
 ie_comment <- '/[' condition:(!']' .)+ ']' space? content:(!eol .)*;
 
 code_comment <- '/' text_block;
+
+verbatim_text <- indent:space? type:[|'] content:text_block;
 
 text_block <- text_block_line (crlf
   indent lines:text_block_nested_lines dedent)?;

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -92,13 +92,14 @@ ie_comment <- '/[' condition:(!']' .)+ ']' space? content:(!eol .)*;
 % TODO: support multi-line
 code_comment <- '/' (!eol .)*;
 
-verbatim_text <- indent:space? type:[|'] space:space? content:verbatim_text_lines;
-verbatim_text_lines <- verbatim_text_line (crlf indent space:space lines:verbatim_text_nested_lines dedent)?;
-verbatim_text_nested_lines <- verbatim_text_line (crlf (
-  indent space:space lines:verbatim_text_nested_lines dedent /
-  space:space lines:verbatim_text_nested_lines
+verbatim_text <- indent:space? type:[|'] content:text_block;
+
+text_block <- text_block_line (crlf
+  indent lines:text_block_nested_lines dedent)?;
+text_block_nested_lines <- text_block_line (crlf (
+  indent text_block_nested_lines dedent / text_block_nested_lines
 ))*;
-verbatim_text_line <- dynamic:text_with_interpolation / simple:text / '';
+text_block_line <- space? (dynamic:text_with_interpolation / simple:text);
 
 embedded_engine <- tag_name ':' (
   crlf indent lines:embedded_engine_lines dedent / empty:('' &eol)

--- a/test/rendering/comments_test.exs
+++ b/test/rendering/comments_test.exs
@@ -1,18 +1,48 @@
 defmodule RenderCommentsTest do
   use ExUnit.Case, async: true
 
-  import Slime, only: [render: 1]
+  import Slime, only: [render: 1, render: 2]
 
-  test "lines started with / are commented out" do
+  test "lines indented deeper than / are commented out" do
     slime = """
-    / code comment
+    / Code comment
+      that spans over multiple lines
+    /
+     Code comment started
+     on another line
     p.test
+    / One-liner
     """
     assert render(slime) == ~s(<p class="test"></p>)
   end
 
   test "/! renders html comments" do
     assert render(~s(/! html comment)) == ~s(<!--html comment-->)
+  end
+
+  test "/! can span over multiple lines" do
+    slime = """
+    div
+      /!
+         HTML comments
+      /! Have similar semantics
+          to other text blocks:
+              they can be nested, with indentation being converted to spaces
+    """
+    html = """
+    <div><!--HTML comments--><!--Have similar semantics
+     to other text blocks:
+         they can be nested, with indentation being converted to spaces--></div>
+    """ |> String.strip(?\n)
+    assert render(slime) == html
+  end
+
+  test "/! renders comments with interpolation" do
+    slime = ~S(/! html comment with #{interpolation})
+    html = """
+    <!--html comment with a-->
+    """ |> String.strip(?\n)
+    assert render(slime, interpolation: "a") == html
   end
 
   test "/![foo] renders IE comments" do

--- a/test/rendering/text_test.exs
+++ b/test/rendering/text_test.exs
@@ -50,6 +50,16 @@ defmodule RenderTextTest do
     assert render(slime) == html
   end
 
+  test "' without any text inserts whitespace" do
+    slime = """
+    p
+      | Text
+      '
+      | with space
+    """
+    assert render(slime) == "<p>Text with space</p>"
+  end
+
   test "render multiline varbatim text with empty first line" do
     slime = """
     p


### PR DESCRIPTION
I've noticed that Slim handles HTML comments (`/!`)  just like verbatim text nodes (`|` and `'`) — complete with interpolation — so I decided to move the common semantics into a `text_block` rule.

The change introduces:
* multiline HTML comments (`/!`)
* text interpolation in HTML comments
* mutlilne code comments (`/`)

What do you think?