### PR TITLE
Fix compiler warnings for hash signs in attribute values

### DIFF
--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -59,7 +59,7 @@ attribute <- attribute_name '=' attribute_value;
 
 attribute_value <- simple:string / dynamic:(string_with_interpolation / attribute_code);
 
-string <- '"' ('\\' . / !('"' / '#') .)* '"';
+string <- '"' ('\\' . / !('"' / '#{') .)* '"';
 string_with_interpolation <- '"' (interpolation / '\\' . / !'"' .)* '"';
 
 attribute_code <- (parentheses / brackets / braces / !(space / eol / ')' / ']' / '}') .)+;

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -122,6 +122,16 @@ defmodule ParserTest do
     ]
   end
 
+  test "hash signs in attributes" do
+    slime = """
+    a href="#" Foo
+    """
+    assert parse(slime) == [
+      %HTMLNode{name: "a", attributes: [{"href", "#"}], children: [
+        %VerbatimTextNode{content: ["Foo"]}]}
+    ]
+  end
+
   test "inline eex" do
     slime = """
     p some-attribute=inline = hey


### PR DESCRIPTION
An attribute value containing a hash sign was being incorrectly parsed as a string with interpolation, which made the compiler generate redundant code:
```
"<a<% slim__k = \"href\"; slim__v = \"#\" %><%= if slim__v do %> <%= slim__k %><%= unless slim__v ==
true do %>=\"<%= slim__v %>\"<% end %><% end %>>Foo</a>"
```
(references #132).