### PR TITLE
Wrapped multiline attributes

### DIFF
--- a/lib/slime/parser/transform.ex
+++ b/lib/slime/parser/transform.ex
@@ -234,6 +234,7 @@ defmodule Slime.Parser.Transform do
   end
 
   def transform(:wrapped_attributes, [_o, attrs, _c], _index), do: attrs
+  def transform(:wrapped_attributes, indented, _index), do: Enum.at(indented, 3)
 
   def transform(:wrapped_attribute, [_space, attribute], _index) do
     case attribute do

--- a/lib/slime/parser/transform.ex
+++ b/lib/slime/parser/transform.ex
@@ -233,16 +233,10 @@ defmodule Slime.Parser.Transform do
     attrs
   end
 
-  def transform(:wrapped_attributes, input, _index), do: Enum.at(input, 1)
+  def transform(:wrapped_attributes, [_o, attrs, _c], _index), do: attrs
 
-  def transform(:wrapped_attributes_list, input, _index) do
-    head = input[:head]
-    tail = Enum.map(input[:tail] || [[]], &List.last/1)
-    [head | tail]
-  end
-
-  def transform(:wrapped_attribute, input, _index) do
-    case input do
+  def transform(:wrapped_attribute, [_space, attribute], _index) do
+    case attribute do
       {:attribute, attr} -> attr
       {:attribute_name, name} -> {name, true}
     end

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -45,13 +45,11 @@ attributes <- wrapped_attributes / plain_attributes;
 wrapped_attributes <-
   <%=
     attr_list_delims
-    |> Enum.map(fn ({open, close}) -> "'#{open}' wrapped_attributes_list '#{close}'" end)
+    |> Enum.map(fn ({open, close}) -> "'#{open}' wrapped_attribute+ '#{close}'" end)
     |> Enum.join(" / ")
   %>;
 
-wrapped_attributes_list <- head:wrapped_attribute tail:(space wrapped_attribute)*;
-
-wrapped_attribute <- attribute:attribute / attribute_name:tag_name;
+wrapped_attribute <- (space / eol)* (attribute:attribute / attribute_name:tag_name);
 
 plain_attributes <- head:attribute tail:(space attribute)*;
 

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -45,7 +45,11 @@ attributes <- wrapped_attributes / plain_attributes;
 wrapped_attributes <-
   <%=
     attr_list_delims
-    |> Enum.map(fn ({open, close}) -> "'#{open}' wrapped_attribute+ '#{close}'" end)
+    |> Enum.flat_map(fn ({open, close}) -> [
+        "'#{open}' crlf+ indent wrapped_attribute+ (eol / space)+ '#{close}'",
+        "'#{open}' wrapped_attribute+ '#{close}'"
+      ]
+    end)
     |> Enum.join(" / ")
   %>;
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -82,6 +82,28 @@ defmodule ParserTest do
     ]
   end
 
+  test "multiline attributes" do
+    slime = """
+    div
+      a(href="/path"
+      title="long title"
+      data-something="value")
+        span(
+        class="icon") Icon
+    """
+    assert parse(slime) == [
+      %HTMLNode{name: "div", attributes: [], children: [
+        %HTMLNode{name: "a",
+          attributes: [
+            {"data-something", "value"}, {"href", "/path"}, {"title", "long title"}],
+          children: [
+            %HTMLNode{name: "span", attributes: [{"class", "icon"}],
+              children: [%Slime.Parser.Nodes.VerbatimTextNode{content: ["Icon"]}]}
+          ]}
+      ]}
+    ]
+  end
+
   test "embedded code" do
     slime = """
     = for thing <- stuff do

--- a/test/rendering/attributes_test.exs
+++ b/test/rendering/attributes_test.exs
@@ -23,6 +23,16 @@ defmodule RenderAttributesTest do
     assert render(slime) == ~s(<div style="display: none"></div>)
   end
 
+  test "attributes can span over multiple lines" do
+    slime = """
+    input[
+    type="text"
+    class="form-control"
+    name="plop"]
+    """
+    assert render(slime) == ~s(<input class="form-control" name="plop" type="text">)
+  end
+
   test "# provides shorthand for assigning ID attributes" do
     assert render(~s(span#id)) == ~s(<span id="id"></span>)
   end

--- a/test/rendering/attributes_test.exs
+++ b/test/rendering/attributes_test.exs
@@ -31,6 +31,16 @@ defmodule RenderAttributesTest do
     name="plop"]
     """
     assert render(slime) == ~s(<input class="form-control" name="plop" type="text">)
+    slime = """
+    section
+      div [
+        style="..."
+        data-content="..."
+      ]
+        p
+    """
+    assert render(slime) ==
+      ~s(<section><div data-content="..." style="..."><p></p></div></section>)
   end
 
   test "# provides shorthand for assigning ID attributes" do


### PR DESCRIPTION
I find it very convenient that Slim allows attributes to be spanned over multiple lines:
```slim
a.link.link--highlighted data-element-class="Object" data-element-id=object.id title="Very long link title" href="#"
```
vs
```slim
a.link.link--highlighted(href="#"
data-element-class="Object"
data-element-id=object.id
title="Very long link title")
```
It'd be nice to have this in Slime.