### PR TITLE
Fix verbatim text indents

### DIFF
--- a/lib/slime/parser/embedded_engine.ex
+++ b/lib/slime/parser/embedded_engine.ex
@@ -22,7 +22,8 @@ defmodule Slime.Parser.EmbeddedEngine do
   @registered_engines Map.keys(@engines)
 
   def parse(engine, lines) when engine in @registered_engines do
-    embedded_text = render_content(lines, 0)
+    # NOTE: Add an empty line to keep spaces consistent with verbatim text case
+    embedded_text = render_content([{0, []} | lines], 0)
 
     {:ok, render_with_engine(engine, embedded_text)}
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,13 @@
-%{"benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
+%{
+  "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
-  "mix_test_watch": {:hex, :mix_test_watch, "0.4.1", "a98a84c795623f1ba020324f4354cf30e7120ba4dab65f9c2ae300f830a25f75", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
   "neotoma": {:hex, :neotoma, "1.7.3", "d8bd5404b73273989946e4f4f6d529e5c2088f5fa1ca790b4dbe81f4be408e61", [:rebar], [], "hexpm"},
   "phoenix_html": {:hex, :phoenix_html, "2.10.4", "d4f99c32d5dc4918b531fdf163e1fd7cf20acdd7703f16f5d02d4db36de803b7", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
-  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"}}
+  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+}

--- a/test/parser/preprocessor_test.exs
+++ b/test/parser/preprocessor_test.exs
@@ -83,4 +83,32 @@ defmodule Slime.Parser.PreprocessorTest do
     d
     """
   end
+
+  test "skip empty lines at the end of verbatim text" do
+    slime = """
+    |
+      Test: <%= "test" %>
+
+    d
+    """
+    assert Preprocessor.indent(slime) == """
+    |
+    #{@indent}  Test: <%= "test" %>#{@dedent}
+
+    d
+    """
+  end
+
+  test "handle one-line verbatim text without unneccessary indent-dedent" do
+    slime = """
+    | Test: <%= "test" %>
+
+    d
+    """
+    assert Preprocessor.indent(slime) == """
+    | Test: <%= "test" %>
+
+    d
+    """
+  end
 end

--- a/test/rendering/embedded_engine_test.exs
+++ b/test/rendering/embedded_engine_test.exs
@@ -50,7 +50,7 @@ defmodule RenderEmbeddedEngineTest do
     assert render(slime) == ~s"""
     <script>alert('Slime supports embedded javascript!')
     alert('Slime supports embedded javascript!')
-      alert('Slime supports embedded javascript!')</script>
+        alert('Slime supports embedded javascript!')</script>
     """ |> String.trim("\n")
   end
 

--- a/test/rendering/text_test.exs
+++ b/test/rendering/text_test.exs
@@ -144,4 +144,47 @@ defmodule RenderTextTest do
     """
     assert render(slime, test: "test") == "<p>test\ntest test</p>"
   end
+
+  test "respect leading spaces in verbatim test" do
+    slime = """
+    p
+      |  test
+        test
+         test
+    """
+    assert render(slime) == "<p> test\ntest\n test</p>"
+  end
+
+  test "verbatim text lines should be indented relative to first line" do
+    slime = """
+    p
+      | foo
+          foo
+         bar
+            baz
+    """
+    assert render(slime) == "<p>foo\n  foo\n bar\n    baz</p>"
+  end
+
+  test "verbatim text lines should be indented relative to first line with separate declaration" do
+    slime = """
+    p
+      |
+          foo
+           bar
+            baz
+    """
+    assert render(slime) == "<p>foo\n bar\n  baz</p>"
+  end
+
+  test "should unindent leading lines if there are less indented lines after them" do
+    slime = """
+    p
+      |
+          foo
+        bar
+            baz
+    """
+    assert render(slime) == "<p>foo\nbar\n    baz</p>"
+  end
 end


### PR DESCRIPTION
closes #131
Leading spaces in verbatim text are now works as in original Slim