### PR TITLE
Support unescaped content, attributes and interpolation

### DIFF
--- a/lib/slime/parser/nodes.ex
+++ b/lib/slime/parser/nodes.ex
@@ -28,12 +28,14 @@ defmodule Slime.Parser.Nodes do
     * :spaces — tag whitespace, represented as a keyword list of boolean
     values for :leading and :trailing,
     * :children — a list of nodes.
+    * :safe? - mark output as safe for html-escaping engines
     """
 
     defstruct content: "",
               output: false,
               spaces: %{},
-              children: []
+              children: [],
+              safe?: false
   end
 
   defmodule VerbatimTextNode do

--- a/lib/slime/renderer.ex
+++ b/lib/slime/renderer.ex
@@ -26,9 +26,9 @@ defmodule Slime.Renderer do
   precompiled templates created with Slime.function_from_file/5 and
   Slime.function_from_string/5.
   """
-  def render(slime, bindings \\ []) do
+  def render(slime, bindings \\ [], opts \\ []) do
     slime
     |> precompile
-    |> EEx.eval_string(bindings)
+    |> EEx.eval_string(bindings, opts)
   end
 end

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -57,18 +57,20 @@ wrapped_attribute <- (space / eol)* (attribute:attribute / attribute_name:tag_na
 
 plain_attributes <- head:attribute tail:(space attribute)*;
 
-attribute <- attribute_name '=' attribute_value;
+attribute <- attribute_name '=' '='? attribute_value;
 
 attribute_value <- simple:string / dynamic:(string_with_interpolation / attribute_code);
 
 string <- '"' ('\\' . / !('"' / '#{') .)* '"';
-string_with_interpolation <- '"' (interpolation / '\\' . / !'"' .)* '"';
+string_with_interpolation <- '"' (elixir_interpolation / '\\' . / !'"' .)* '"';
 
 attribute_code <- (parentheses / brackets / braces / !(space / eol / ')' / ']' / '}') .)+;
 
-text_item <- static:text / dynamic:interpolation;
+text_item <- static:text / dynamic:(safe:safe_interpolation / interpolation);
 text <- ('\\' . / !('#{' / eol) .)+;
+elixir_interpolation <- '#{' (string / string_with_interpolation / !'}' .)* '}';
 interpolation <- '#{' (string / string_with_interpolation / !'}' .)* '}';
+safe_interpolation <- '#{{' (string / string_with_interpolation / !'}}' .)* '}}';
 
 parentheses <- '(' (parentheses / !')' .)* ')';
 brackets <- '[' (brackets / !']' .)* ']';

--- a/test/rendering/elixir_test.exs
+++ b/test/rendering/elixir_test.exs
@@ -24,11 +24,6 @@ defmodule RenderElixirTest do
     assert render(slime) == "2"
   end
 
-  test "== evalutes Elixir and inserts the result (unescaped version)" do
-    slime = "== 1 + 1"
-    assert render(slime) == "2"
-  end
-
   test "= can be used inside an element (space before)" do
     slime = "div = 1 + 1"
     assert render(slime) == "<div>2</div>"

--- a/test/rendering/raw_output_test.exs
+++ b/test/rendering/raw_output_test.exs
@@ -1,0 +1,41 @@
+defmodule RawOutputTest do
+  use ExUnit.Case
+
+  alias Slime.Renderer
+  alias Phoenix.HTML
+  alias Phoenix.HTML.Engine
+
+  defp render(template, bindings \\ []) do
+    template
+    |> Renderer.render(bindings, engine: Engine)
+    |> HTML.safe_to_string
+  end
+
+  test "render raw dynamic content" do
+    slime = """
+    == "<>"
+    """
+    assert render(slime) == "<>"
+  end
+
+  test "render raw attribute value" do
+    slime = """
+    a href==href
+    """
+    assert render(slime, href: "&") == ~s[<a href="&"></a>]
+  end
+
+  test "render raw tag content" do
+    slime = """
+    p == "<>"
+    """
+    assert render(slime) == ~s[<p><></p>]
+  end
+
+  test "render raw text interpolation" do
+    slime = ~S"""
+    | test #{{"<>"}}
+    """
+    assert render(slime) == "test <>"
+  end
+end


### PR DESCRIPTION
This is straight-forward implementation of unescaped content (`== foo`, `p == bar`), attributes (`a href=="&"`), and interpolation in text blocks (`| foo #{{bar}}`).

***This new syntax will only work with `engine: Phoenix.HTML.Engine` option*** (for example in phoenix_slime), because it produce eex templates with dynamic parts like this: `<%= {:safe, content} %>`.
Default slime behaviour is still not to escape any output.

Things to discuss before merge: 

- should we change default engine to escaping engine like `Phoenix.HTML.Engine`?
- should we add a config option to turn on/off this new syntax?
- should we provide a configuration options for changing the way of marking output as safe? (now `{:safe, output}` is hardcoded.

TODO:

- [ ] Update readme 

closes #114 