### PR TITLE
Adds the ability to specify attributes via lists

### DIFF
--- a/lib/slime/compiler.ex
+++ b/lib/slime/compiler.ex
@@ -95,10 +95,11 @@ defmodule Slime.Compiler do
     ~s[ #{name}="#{quoted}"]
   end
 
-  defp render_attribute_code(name, _cotnent, quoted, safe) when is_binary(quoted) do
-    value = if :eex == safe, do: quoted, else: ~s[<%= {:safe, "#{quoted}"} %>]
-    ~s[ #{name}="#{value}"]
+  defp render_attribute_code(name, _content, quoted, _) when is_list(quoted) do
+    quoted |> Enum.map_join(" ", &Kernel.to_string/1) |> (& ~s[ #{name}="#{&1}"]).()
   end
+  defp render_attribute_code(name, _content, quoted, :eex) when is_binary(quoted), do: ~s[ #{name}="#{quoted}"]
+  defp render_attribute_code(name, _content, quoted, _) when is_binary(quoted), do: ~s[ #{name}="<%= {:safe, "#{quoted}"} %>"]
 
   # NOTE: string with interpolation or strings concatination
   defp render_attribute_code(name, content, {op, _, _}, safe) when op in [:<<>>, :<>] do

--- a/lib/slime/parser/attributes_keyword.ex
+++ b/lib/slime/parser/attributes_keyword.ex
@@ -51,9 +51,17 @@ defmodule Slime.Parser.AttributesKeyword do
   defp dynamic_value?(_), do: false
 
   defp join_attribute_values(values, join_by) do
-    values |> Enum.map(&attribute_val/1) |> List.flatten |> Enum.join(join_by)
+    values |> Enum.map(&attribute_val(&1, join_by)) |> List.flatten |> Enum.join(join_by)
   end
 
-  defp attribute_val({:eex, content}), do: "\#{" <> content <> "}"
-  defp attribute_val(value), do: value
+  defp attribute_val({:eex, content}, join_by) do
+    case Code.string_to_quoted!(content) do
+      list when is_list(list) ->
+        list |> List.flatten |> Enum.join(join_by)
+      _ -> "\#{" <> content <> "}"
+    end
+  end
+
+  defp attribute_val(value, _), do: value
+
 end

--- a/test/rendering/attributes_test.exs
+++ b/test/rendering/attributes_test.exs
@@ -101,6 +101,10 @@ defmodule RenderAttributesTest do
     ) == ~s(<meta content="1,2,3">)
   end
 
+  test "parses attributes with lists" do
+    assert render(~S{meta content=["a", "b", "c"]}) == ~s{<meta content="a b c">}
+  end
+
   test "attributes values can contain `=` character" do
     template = ~s(meta content="width=device-width, initial-scale=1")
     html = ~s(<meta content="width=device-width, initial-scale=1">)
@@ -110,6 +114,12 @@ defmodule RenderAttributesTest do
   test "shorthand and literal class attributes are merged" do
     template = ~s(.class-one class="class-two")
     assert render(template) == ~s(<div class="class-one class-two"></div>)
+  end
+
+  test "shorthand and literal class attributes are merged with list awareness" do
+
+    template = ~s(.class-one class=["class-two", "class-three"])
+    assert render(template) == ~s(<div class="class-one class-two class-three"></div>)
   end
 
   test "attributes can have dynamic values" do


### PR DESCRIPTION
The ruby slim specification states that attributes can be provided by an array

```slim
body class=["hello", "world"]
```

with the expected output of

```html
<body class="hello world"></body>
```

This PR introduces that feature.

Additionally, I added support for lists to the attribute merge module, so you can do the following

```slim
.class-one class=["class-two", "class-three"]
```

and get

```html
<div class="class-one class-two class-three"></div>
```

This fixes https://github.com/slime-lang/slime/issues/156