### PR TITLE
Add neotoma to extra_applications for elixir 1.15 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Slime.Mixfile do
 
   def application do
     [
-      applications: [:eex]
+      extra_applications: [:eex, :neotoma],
     ]
   end
 


### PR DESCRIPTION
Needed to avoid a compilation failure with 1.15
```
** (UndefinedFunctionError) function :neotoma.file/2 is undefined (module :neotoma is not available)
    (neotoma 1.7.3) :neotoma.file(~c"/tmp/slime/src/slime_parser.peg", [transform_module: :slime_parser_transform])
    tasks/compile.peg.exs:37: Mix.Tasks.Compile.Peg.compile_grammar/2
    (mix 1.15.4) lib/mix/task.ex:447: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.15.4) lib/mix/tasks/compile.all.ex:124: Mix.Tasks.Compile.All.run_compiler/2
    (mix 1.15.4) lib/mix/tasks/compile.all.ex:104: Mix.Tasks.Compile.All.compile/4
    (mix 1.15.4) lib/mix/tasks/compile.all.ex:93: Mix.Tasks.Compile.All.with_logger_app/2
    (mix 1.15.4) lib/mix/tasks/compile.all.ex:56: Mix.Tasks.Compile.All.run/1
    (mix 1.15.4) lib/mix/task.ex:447: anonymous fn/3 in Mix.Task.run_task/5
```